### PR TITLE
Fix render error of White Paper on tablets

### DIFF
--- a/src/app/app-styles.scss
+++ b/src/app/app-styles.scss
@@ -1,10 +1,6 @@
 /* ----------
 APP
 ---------- */
-.app {
-  min-height: 100%;
-}
-
 .app__show-on-mobile {
   display: block;
 }
@@ -22,6 +18,18 @@ APP
 @media (max-width: 600px) {
   .app__hide-on-mobile {
     display: none;
+  }
+}
+
+@media (min-width: 400px) and (max-width: 800px) {
+  .app__hide-on-tablet {
+    display: none;
+  }
+}
+
+@media (min-width: 400px) and (max-width: 800px) {
+  .app__show-on-tablet {
+    display: block;
   }
 }
 

--- a/src/views/About.js
+++ b/src/views/About.js
@@ -103,13 +103,13 @@ export default function About() {
           <div className="about__block-pair">
             <div className="about__block--left">
               <NavLink
-                className="app__nav-link static-page__link static-page__link--highlight app__hide-on-mobile"
+                className="app__nav-link static-page__link static-page__link--highlight app__hide-on-mobile app__hide-on-tablet"
                 to="/whitepaper"
               >
                 The TruSat white paper
               </NavLink>
               <a
-                className="static-page__link static-page__link--highlight app__hide-on-desktop"
+                className="static-page__link static-page__link--highlight app__show-on-tablet app__hide-on-desktop"
                 target="_blank"
                 and
                 rel="noopener noreferrer"

--- a/src/views/FAQ.js
+++ b/src/views/FAQ.js
@@ -386,13 +386,13 @@ export default function FAQ() {
         <p className="static-page__copy">
           Curious for a technical deep dive into how TruSat works? Check out the{" "}
           <NavLink
-            className="app__nav-link static-page__link app__hide-on-mobile"
+            className="app__nav-link static-page__link app__hide-on-mobile app__hide-on-tablet"
             to="/whitepaper"
           >
             TruSat white paper
           </NavLink>
           <a
-            className="static-page__link app__hide-on-desktop"
+            className="static-page__link app__show-on-tablet app__hide-on-desktop"
             target="_blank"
             and
             rel="noopener noreferrer"


### PR DESCRIPTION
- Adds conditional render for whitepaper links on `About` and `FAQ` pages to view the White Paper on AWS as opposed to a route within the app. 
- Whitepaper will only be viewed within iframe at `/whitepaper` route on desktop.