### PR TITLE
Refactor of object view components to prevent hitting API twice

### DIFF
--- a/src/objects/components/DownloadObjectTleButton.js
+++ b/src/objects/components/DownloadObjectTleButton.js
@@ -9,7 +9,9 @@ export default function DownloadObjectTleButton() {
   const [{ isLoading, isError, data }, doFetch] = useTrusatGetApi();
 
   useEffect(() => {
-    doFetch(`/tle/object?norad_number=${noradNumber}`);
+    if (noradNumber && data.length === 0) {
+      doFetch(`/tle/object?norad_number=${noradNumber}`);
+    }
 
     setTleString(data);
   }, [noradNumber, doFetch, data]);

--- a/src/objects/components/Info.js
+++ b/src/objects/components/Info.js
@@ -24,13 +24,15 @@ export default function Info() {
         </p>
       )}
       <section className="object-info__header-section-wrapper">
-        <div className="object-info__badge-wrapper">
-          <ObjectBadge
-            noradNumber={noradNumber}
-            size="large"
-            addStyles={`object-badge__wrapper--object-view`}
-          />
-        </div>
+        {noradNumber ? (
+          <div className="object-info__badge-wrapper">
+            <ObjectBadge
+              noradNumber={noradNumber}
+              size="large"
+              addStyles={`object-badge__wrapper--object-view`}
+            />
+          </div>
+        ) : null}
 
         <div>
           <h1 className="object-info__header">{objectInfo.object_name}</h1>

--- a/src/views/ObjectInfo.js
+++ b/src/views/ObjectInfo.js
@@ -11,7 +11,6 @@ import {
 import FilterDescription from "../objects/components/FilterDescription";
 import Spinner from "../app/components/Spinner";
 import { useTrusatGetApi } from "../app/app-helpers";
-import { SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG } from "constants";
 
 // Check if noradNumber from url is not more than 5 characters long
 // and if it only contains numbers

--- a/src/views/ObjectInfo.js
+++ b/src/views/ObjectInfo.js
@@ -11,6 +11,7 @@ import {
 import FilterDescription from "../objects/components/FilterDescription";
 import Spinner from "../app/components/Spinner";
 import { useTrusatGetApi } from "../app/app-helpers";
+import { SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG } from "constants";
 
 // Check if noradNumber from url is not more than 5 characters long
 // and if it only contains numbers
@@ -29,13 +30,14 @@ export default function ObjectInfo({ match }) {
   const [isNumberError, setIsNumberError] = useState(false);
 
   useEffect(() => {
-    // only fetch data for a potentially valid norad number
-    if (!isValidNumber(noradNumber)) {
-      setIsNumberError(true);
-    } else {
+    if (isValidNumber(noradNumber) && data.length === 0) {
       doFetch(`/object/info?norad_number=${noradNumber}`);
+    } else if (!isValidNumber(noradNumber)) {
+      setIsNumberError(true);
     }
+  }, [noradNumber, data, doFetch]);
 
+  useEffect(() => {
     if (data.length !== 0) {
       objectsDispatch({ type: "SET_NORAD_NUMBER", payload: noradNumber });
       objectsDispatch({ type: "SET_OBJECT_INFO", payload: data });
@@ -48,7 +50,7 @@ export default function ObjectInfo({ match }) {
         payload: data.year_launched
       });
     }
-  }, [noradNumber, data, doFetch, objectsDispatch]);
+  }, [noradNumber, data, objectsDispatch]);
 
   return isNumberError ? (
     <p className="app__error-message">


### PR DESCRIPTION
- Adds some logic to prevent `/object` endpoints getting hit twice when `/object` route is visited.
- changes are deployed to devvy site 
- closes #56 