### PR TITLE
Fix issue of iPad not rendering White Paper

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version",
-      "ie 11"
+      "last 1 ie version"
     ]
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
     <title>TruSat</title>
   </head>
   <body>

--- a/src/views/ObjectInfo.js
+++ b/src/views/ObjectInfo.js
@@ -15,7 +15,7 @@ import { useTrusatGetApi } from "../app/app-helpers";
 // Check if noradNumber from url is not more than 5 characters long
 // and if it only contains numbers
 const isValidNumber = number => {
-  if (number.length > 5 || /^\d+$/.test(number) === false) {
+  if (number < 1 || /^(\d{1,5})$/.test(number) === false) {
     return false;
   }
   return true;


### PR DESCRIPTION
- Converted the `NavLink` to `/whitepaper` route to an anchor tag that opens a new tab, rendering the whitepaper from AWS
- This works across all devices
- Future work will be needed to utilize the `/whitepaper` route within the app, as it is no longer linked to via the `NavBar`