### PR TITLE
Add routes for TLE lists

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -116,6 +116,23 @@ export default function App() {
             component={SubscriptionConfirmed}
           />
           <Route path="/test-pilot-confirmed" component={TestPilotConfirmed} />
+          {/* TLE Routes */}
+          <Route
+            path="/tle/priorities"
+            component={() => {
+              window.location.href =
+                "https://api.trusat.org:8080/tle/trusat_priorities.txt";
+              return null;
+            }}
+          />
+          <Route
+            path="/tle/all"
+            component={() => {
+              window.location.href =
+                "https://api.trusat.org:8080/tle/trusat_all.txt";
+              return null;
+            }}
+          />
           <Route component={NoMatch} />
         </Switch>
 


### PR DESCRIPTION
Adds the following routes:

- `/tle/priorities`
- `/tle/all`

Which forward to the API addresses and render the TLEs in the browser