### PR TITLE
Fixes issue of users submitting observations via burner wallets

### DIFF
--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -353,6 +353,11 @@ export default function SingleObservationForm({
 
   return (
     <Fragment>
+      {jwt === "none" ? (
+        <p className="app__error-message">
+          Please log in to submit your observations
+        </p>
+      ) : null}
       <form
         className="single-observation-form"
         onSubmit={event => {
@@ -1142,12 +1147,14 @@ export default function SingleObservationForm({
               Or enter pre-formatted data
             </span>
 
-            <button
-              className="submit__submit-button"
-              style={showSubmitButton ? { opacity: "1" } : { opacity: "0.5" }}
-            >
-              SUBMIT
-            </button>
+            {jwt === "none" ? null : (
+              <button
+                className="submit__submit-button"
+                style={showSubmitButton ? { opacity: "1" } : { opacity: "0.5" }}
+              >
+                SUBMIT
+              </button>
+            )}
           </div>
         )}
       </form>


### PR DESCRIPTION
- Closes #148 
- Logged out users will now see a prompt to log in at the top of both submission forms
- The submit button at bottom of the forms is now hidden if the user is not logged in which will prevent them from submitting an observation without a JWT to identify themselves