### PR TITLE
Feature/single iod form

### DIFF
--- a/src/app/app-helpers.js
+++ b/src/app/app-helpers.js
@@ -202,18 +202,12 @@ export const toolTipCopy = {
     "The UTC time you saw the satellite at the position specified below",
   time_uncertainty:
     "The margin of uncertainty, as a measure of time, for your estimated time of observation",
-  sky_conditions: `Excellent: No Moon/clouds, great seeing, minimal air/light pollution.
-  
-  Good: No Moon/clouds, conditions could be better, but not much.
-
-  Fair: Young/old Moon, some air/light pollution making fainter stars invisible.
-
-  Poor: Gibbous Moon, haze, more air/light pollution making more stars invisible.
-
-  Bad: Bright Moon, air/light pollution, some clouds; difficult.
-
-  Terrible: Bright Moon, air/light pollution, looking through clouds.
-  `,
+  sky_conditions_excellent: `No Moon/clouds, great seeing, minimal air/light pollution.`,
+  sky_conditions_good: `No Moon/clouds, conditions could be better, but not much.`,
+  sky_conditions_fair: `Young/old Moon, some air/light pollution making fainter stars invisible.`,
+  sky_conditions_poor: `Gibbous Moon, haze, more air/light pollution making more stars invisible.`,
+  sky_conditions_bad: `Bright Moon, air/light pollution, some clouds; difficult.`,
+  sky_conditions_terrible: `Bright Moon, air/light pollution, looking through clouds.`,
   position_format:
     "Different software may provide you with different formats for reporting position. This form supports the most common types.",
   epoch_code:

--- a/src/submissions/components/MultipleObservationForm.js
+++ b/src/submissions/components/MultipleObservationForm.js
@@ -111,7 +111,7 @@ export default function MultipleObservationForm({
         <Fragment>
           <div className="multiple-observation-form__button-wrapper">
             <span
-              className="submit__single-observation-nav-button"
+              className="submit__single-observation-nav-button app__hide-on-mobile app__hide-on-tablet"
               onClick={() => setShowSingleObservationForm(true)}
             >
               Or enter individual observation

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -558,10 +558,7 @@ export default function SingleObservationForm({
           {/* Conditions */}
           {isHiddenInputs ? null : (
             <div className="station-conditions__conditions-wrapper">
-              <label>
-                Sky Conditions (optional){" "}
-                <QuestionMarkToolTip toolTipText={toolTipCopy.sky_conditions} />
-              </label>
+              <label>Sky Conditions (optional) </label>
               <div className="station-conditions__conditions-buttons-wrapper">
                 <div>
                   <img
@@ -574,7 +571,10 @@ export default function SingleObservationForm({
                     }
                     onClick={() => setConditions("E")}
                   ></img>
-                  Excellent
+                  Excellent{" "}
+                  <QuestionMarkToolTip
+                    toolTipText={toolTipCopy.sky_conditions_excellent}
+                  />
                 </div>
                 <div>
                   <img
@@ -587,7 +587,10 @@ export default function SingleObservationForm({
                     }
                     onClick={() => setConditions("G")}
                   ></img>
-                  Good
+                  Good{" "}
+                  <QuestionMarkToolTip
+                    toolTipText={toolTipCopy.sky_conditions_good}
+                  />
                 </div>
 
                 <div>
@@ -601,7 +604,10 @@ export default function SingleObservationForm({
                     }
                     onClick={() => setConditions("F")}
                   ></img>
-                  Fair
+                  Fair{" "}
+                  <QuestionMarkToolTip
+                    toolTipText={toolTipCopy.sky_conditions_fair}
+                  />
                 </div>
                 <div>
                   <img
@@ -614,7 +620,10 @@ export default function SingleObservationForm({
                     }
                     onClick={() => setConditions("P")}
                   ></img>
-                  Poor
+                  Poor{" "}
+                  <QuestionMarkToolTip
+                    toolTipText={toolTipCopy.sky_conditions_poor}
+                  />
                 </div>
 
                 <div>
@@ -628,7 +637,10 @@ export default function SingleObservationForm({
                     }
                     onClick={() => setConditions("B")}
                   ></img>
-                  Bad
+                  Bad{" "}
+                  <QuestionMarkToolTip
+                    toolTipText={toolTipCopy.sky_conditions_bad}
+                  />
                 </div>
                 <div>
                   <img
@@ -641,7 +653,10 @@ export default function SingleObservationForm({
                     }
                     onClick={() => setConditions("T")}
                   ></img>
-                  Terrible
+                  Terrible{" "}
+                  <QuestionMarkToolTip
+                    toolTipText={toolTipCopy.sky_conditions_terrible}
+                  />
                 </div>
               </div>
             </div>

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -49,10 +49,11 @@ export default function SingleObservationForm({
   const [positionalUncertainty, setPositionalUncertainty] = useState(`18`); // 2 chars
   // BEHAVIOR
   const [behavior, setBehavior] = useState(` `); // 1 char
-  const [visualMagnitudeSign, setVisualMagnitudeSign] = useState("+"); // 1 char
+  const [showBehaviorOptions, setShowBehaviorOptions] = useState(false); // Utilized to render behavior options when user selected an optical behavior
+  const [visualMagnitudeSign, setVisualMagnitudeSign] = useState(` `); // 1 char
   const [visualMagnitude, setVisualMagnitude] = useState(`   `); // 3 chars
   const [visualMagnitudeUncertainty, setVisualMagnitudeUncertainty] = useState(
-    "10"
+    `  `
   );
   const [flashPeriod, setFlashPeriod] = useState(`      `); // 6 chars
   const [remarks, setRemarks] = useState("");
@@ -305,6 +306,20 @@ export default function SingleObservationForm({
     });
   };
 
+  // Show behavior options when user chooses an Optical Behavior
+  useEffect(() => {
+    if (behavior !== ` `) {
+      setShowBehaviorOptions(true);
+      setVisualMagnitudeSign("+");
+      setVisualMagnitudeUncertainty("10");
+    } else {
+      setShowBehaviorOptions(false);
+      setVisualMagnitudeSign(` `); // ` char
+      setVisualMagnitudeUncertainty(`  `); // 2 chars
+    }
+  }, [behavior]);
+
+  // Only show submit button in full color when no errors present in form
   useEffect(() => {
     if (
       !isStationError &&
@@ -1020,105 +1035,110 @@ export default function SingleObservationForm({
                 <option value="V">Best seen using averted vision</option>
               </select>
             </div>
-            <div className="object-behavior__brightness-brightness-uncertainty-wrapper">
-              <div className="object-behavior__brightness-wrapper">
-                <label>
-                  Brightness{" "}
-                  <QuestionMarkToolTip toolTipText={toolTipCopy.brightness} />
-                </label>
-                <div className="object-behavior__brightness">
+            {showBehaviorOptions ? (
+              <div className="object-behavior__brightness-brightness-uncertainty-wrapper">
+                <div className="object-behavior__brightness-wrapper">
+                  <label>
+                    Brightness{" "}
+                    <QuestionMarkToolTip toolTipText={toolTipCopy.brightness} />
+                  </label>
+                  <div className="object-behavior__brightness">
+                    <select
+                      className="app__form__input app__form__input--sign"
+                      onChange={event =>
+                        setVisualMagnitudeSign(event.target.value)
+                      }
+                      value={visualMagnitudeSign}
+                    >
+                      <option value="+">+</option>
+                      <option value="-">-</option>
+                    </select>
+                    <select
+                      className="object-behavior__brightness-select app__form__input"
+                      type="number"
+                      onChange={event => setVisualMagnitude(event.target.value)}
+                      value={visualMagnitude}
+                    >
+                      <option value={`   `} disabled hidden>
+                        Magnitude
+                      </option>
+                      <option value="010">1</option>
+                      <option value="020">2</option>
+                      <option value="030">3</option>
+                      <option value="040">4</option>
+                      <option value="050">5</option>
+                      <option value="060">6</option>
+                      <option value="070">7</option>
+                      <option value="080">8</option>
+                      <option value="090">9</option>
+                    </select>
+                  </div>
+                </div>
+                <div className="object-behavior__brightness-uncertainty-wrapper">
+                  <label>
+                    Brightness uncertainty{" "}
+                    <QuestionMarkToolTip
+                      toolTipText={toolTipCopy.brightness_uncertainty}
+                    />
+                  </label>
                   <select
-                    className="app__form__input app__form__input--sign"
+                    className="object-behavior__brightness-uncertainty-select app__form__input"
                     onChange={event =>
-                      setVisualMagnitudeSign(event.target.value)
+                      setVisualMagnitudeUncertainty(event.target.value)
                     }
-                    value={visualMagnitudeSign}
+                    value={visualMagnitudeUncertainty}
                   >
-                    <option value="+">+</option>
-                    <option value="-">-</option>
+                    <option value={`01`}>0.1</option>
+                    <option value={`02`}>0.2</option>
+                    <option value={`03`}>0.3</option>
+                    <option value={`04`}>0.4</option>
+                    <option value={`05`}>0.5</option>
+                    <option value={`06`}>0.6</option>
+                    <option value={`07`}>0.7</option>
+                    <option value={`08`}>0.8</option>
+                    <option value={`09`}>0.9</option>
+                    <option value={`10`}>1</option>
+                    <option value={`11`}>1.1</option>
+                    <option value={`12`}>1.2</option>
+                    <option value={`13`}>1.3</option>
+                    <option value={`14`}>1.4</option>
+                    <option value={`15`}>1.5</option>
                   </select>
+                </div>
+                <div className="object-behavior__flash-period-wrapper">
+                  <label>
+                    Flash Period{" "}
+                    <QuestionMarkToolTip
+                      toolTipText={toolTipCopy.flash_period}
+                    />
+                  </label>
                   <select
-                    className="object-behavior__brightness-select app__form__input"
-                    type="number"
-                    onChange={event => setVisualMagnitude(event.target.value)}
-                    value={visualMagnitude}
+                    className="object-behavior__flash-period-select app__form__input"
+                    onChange={event => setFlashPeriod(event.target.value)}
+                    value={flashPeriod}
                   >
-                    <option value={`   `} disabled hidden>
-                      Magnitude
-                    </option>
-                    <option value="010">1</option>
-                    <option value="020">2</option>
-                    <option value="030">3</option>
-                    <option value="040">4</option>
-                    <option value="050">5</option>
-                    <option value="060">6</option>
-                    <option value="070">7</option>
-                    <option value="080">8</option>
-                    <option value="090">9</option>
+                    <option value={`      `}>Not specified</option>
+                    <option value={` 05000`}>0.5 seconds</option>
+                    <option value={` 10000`}>1 seconds</option>
+                    <option value={` 15000`}>1.5 seconds</option>
+                    <option value={` 20000`}>2 seconds</option>
+                    <option value={` 25000`}>2.5 seconds</option>
+                    <option value={` 30000`}>3 seconds</option>
+                    <option value={` 35000`}>3.5 seconds</option>
+                    <option value={` 40000`}>4 seconds</option>
+                    <option value={` 45000`}>4.5 seconds</option>
+                    <option value={` 50000`}>5 seconds</option>
+                    <option value={` 55000`}>5.5 seconds</option>
+                    <option value={` 60000`}>6 seconds</option>
+                    <option value={` 65000`}>6.5 seconds</option>
+                    <option value={` 70000`}>7 seconds</option>
+                    <option value={` 75000`}>7.5 seconds</option>
+                    <option value={` 80000`}>8 seconds</option>
                   </select>
                 </div>
               </div>
-              <div className="object-behavior__brightness-uncertainty-wrapper">
-                <label>
-                  Brightness uncertainty{" "}
-                  <QuestionMarkToolTip
-                    toolTipText={toolTipCopy.brightness_uncertainty}
-                  />
-                </label>
-                <select
-                  className="object-behavior__brightness-uncertainty-select app__form__input"
-                  onChange={event =>
-                    setVisualMagnitudeUncertainty(event.target.value)
-                  }
-                  value={visualMagnitudeUncertainty}
-                >
-                  <option value={`01`}>0.1</option>
-                  <option value={`02`}>0.2</option>
-                  <option value={`03`}>0.3</option>
-                  <option value={`04`}>0.4</option>
-                  <option value={`05`}>0.5</option>
-                  <option value={`06`}>0.6</option>
-                  <option value={`07`}>0.7</option>
-                  <option value={`08`}>0.8</option>
-                  <option value={`09`}>0.9</option>
-                  <option value={`10`}>1</option>
-                  <option value={`11`}>1.1</option>
-                  <option value={`12`}>1.2</option>
-                  <option value={`13`}>1.3</option>
-                  <option value={`14`}>1.4</option>
-                  <option value={`15`}>1.5</option>
-                </select>
-              </div>
-              <div className="object-behavior__flash-period-wrapper">
-                <label>
-                  Flash Period{" "}
-                  <QuestionMarkToolTip toolTipText={toolTipCopy.flash_period} />
-                </label>
-                <select
-                  className="object-behavior__flash-period-select app__form__input"
-                  onChange={event => setFlashPeriod(event.target.value)}
-                  value={flashPeriod}
-                >
-                  <option value={`      `}>Not specified</option>
-                  <option value={` 05000`}>0.5 seconds</option>
-                  <option value={` 10000`}>1 seconds</option>
-                  <option value={` 15000`}>1.5 seconds</option>
-                  <option value={` 20000`}>2 seconds</option>
-                  <option value={` 25000`}>2.5 seconds</option>
-                  <option value={` 30000`}>3 seconds</option>
-                  <option value={` 35000`}>3.5 seconds</option>
-                  <option value={` 40000`}>4 seconds</option>
-                  <option value={` 45000`}>4.5 seconds</option>
-                  <option value={` 50000`}>5 seconds</option>
-                  <option value={` 55000`}>5.5 seconds</option>
-                  <option value={` 60000`}>6 seconds</option>
-                  <option value={` 65000`}>6.5 seconds</option>
-                  <option value={` 70000`}>7 seconds</option>
-                  <option value={` 75000`}>7.5 seconds</option>
-                  <option value={` 80000`}>8 seconds</option>
-                </select>
-              </div>
-            </div>
+            ) : null}
+
             <div className="object-behavior__remarks-wrapper">
               <label>Remarks</label>
               <textarea

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -752,7 +752,7 @@ export default function SingleObservationForm({
                   }
                   onChange={event => setEpochCode(event.target.value)}
                 >
-                  <option value="0">0 or blank = of date</option>
+                  <option value="0">blank = of date</option>
                   <option
                     disabled={
                       Number(angleFormatCode) > 3 && Number(angleFormatCode) < 7
@@ -991,9 +991,7 @@ export default function SingleObservationForm({
                 onChange={event => setBehavior(event.target.value)}
                 value={behavior}
               >
-                <option value={` `} disabled hidden>
-                  Select one
-                </option>
+                <option value={` `}>Not specified</option>
                 <option value="E">
                   Unusually faint because of eclipse exit/entrance
                 </option>
@@ -1101,6 +1099,7 @@ export default function SingleObservationForm({
                   onChange={event => setFlashPeriod(event.target.value)}
                   value={flashPeriod}
                 >
+                  <option value={`      `}>Not specified</option>
                   <option value={` 05000`}>0.5 seconds</option>
                   <option value={` 10000`}>1 seconds</option>
                   <option value={` 15000`}>1.5 seconds</option>

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -111,6 +111,30 @@ export default function SingleObservationForm({
     flashPeriod
   ]);
 
+  // Updates IOD when user toggles `Clouded Out` or `Observer Unavailable`
+  useEffect(() => {
+    if (conditions === "C" || conditions === "O") {
+      setObject(`               `); // 15 chars
+      setTimeUncertainty(`  `); // 2 chars
+      setAngleFormatCode(` `); // 1 char
+      setEpochCode(` `); // 1 char
+      setDeclinationOrElevationSign(` `); // 1 char
+      setPositionalUncertainty(`  `); // 2 chars
+      setVisualMagnitudeSign(` `); // 1 char
+      setVisualMagnitudeUncertainty(`  `); // 2 chars
+    } else {
+      // return all the 'default values' when user deselects either C or O
+      setObject(``); // 15 chars
+      setTimeUncertainty(`18`);
+      setAngleFormatCode(`2`);
+      setEpochCode(`5`);
+      setDeclinationOrElevationSign(`+`);
+      setPositionalUncertainty(`18`);
+      setVisualMagnitudeSign(`+`);
+      setVisualMagnitudeUncertainty(`10`);
+    }
+  }, [conditions]);
+
   // Checks if observation date is before current date
   useEffect(() => {
     if (date.length === 8) {
@@ -127,6 +151,7 @@ export default function SingleObservationForm({
                 .substring(0, 8)
         }`
       );
+      // TODO - add additional check to reject observations from too long ago
       const observationTimeStamp = observationDateTime.getTime();
 
       if (observationTimeStamp > todayTimeStamp) {

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -74,8 +74,6 @@ export default function SingleObservationForm({
     setIsDeclinationOrElevationError
   ] = useState(false);
 
-  //const iodRegEx = /^(\d{5}\s\d{2}\s\d{3}(?=[A-Z]+\s*)[\D\s]{3}(?<!\s\w)\s|\s{16})\d{4}\s[EGFPBTCO ]\s[\d+]{8}(\d*\s*$|(?=.{9})\d*\s*?\s\d{2}\s([1-7][\s0-6]\s(?=[\d\s*]{7})\d+\s*?[+-](?=[\d\s*]{6})\d+\s*?\s\d{2}|\s{20})(\s[EFIRSXBHPADMNV]([+-](?=[\d\s*?]{3})\d+\s*?\s(?=[\d\s*?]{2})\d+\s*?\s(\s+\d+$)?)?)?)/;
-
   // SUBMISSION UI STATES
   const [showSubmitButton, setShowSubmitButton] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -114,6 +112,7 @@ export default function SingleObservationForm({
   // Updates IOD when user toggles `Clouded Out` or `Observer Unavailable`
   useEffect(() => {
     if (conditions === "C" || conditions === "O") {
+      setIsHiddenInputs(true); // clear N/A inputs
       setObject(`               `); // 15 chars
       setTimeUncertainty(`  `); // 2 chars
       setAngleFormatCode(` `); // 1 char
@@ -123,6 +122,7 @@ export default function SingleObservationForm({
       setVisualMagnitudeSign(` `); // 1 char
       setVisualMagnitudeUncertainty(`  `); // 2 chars
     } else {
+      setIsHiddenInputs(false); // shows all inputs again
       // return all the 'default values' when user deselects either C or O
       setObject(``); // 15 chars
       setTimeUncertainty(`18`);
@@ -135,7 +135,7 @@ export default function SingleObservationForm({
     }
   }, [conditions]);
 
-  // Checks if observation date is before current date
+  // Validates if observation date submitted is before current date
   useEffect(() => {
     if (date.length === 8) {
       const todayDate = new Date(); // get todays date
@@ -162,7 +162,7 @@ export default function SingleObservationForm({
     }
   }, [date, time]);
 
-  // Input field format validation
+  // Validates formats of form fields
   useEffect(() => {
     // station is mandatory, must be 4 chars long, all numbers
     if (station.length !== 4 || !numRegEx.test(station)) {
@@ -241,17 +241,6 @@ export default function SingleObservationForm({
     rightAscensionOrAzimuth,
     declinationOrElevation
   ]);
-
-  // when 'Clouded Out' or 'Observer Unavailable' is selected, clear inputs that aren't applicable
-  useEffect(() => {
-    if (conditions === "C" || conditions === "O") {
-      setIsHiddenInputs(true);
-      setObject(`               `); // 15 chars of whitespace to ensure a valid IOD format
-    } else {
-      setIsHiddenInputs(false);
-      setObject(``); // reset object value so that placeholder appears again
-    }
-  }, [conditions]);
 
   // Search for objects in the database
   useEffect(() => {


### PR DESCRIPTION
- Link to `SingleObservationForm` now hidden on mobile and tablet renders
- Added effect hook that will clear all of the default values from the generated IOD string when the users chooses either `Clouded Out` or `Observer Unavailable` checkboxes, and return the values if they uncheck
- Adds tooltip to all of the `Sky Conditions` options to improve readability of what was very length tooltip copy for all conditions
- `Optical Behavior` now defaults to `Not specified` and only when a behavior option is chosen will the default values for behavior related inputs be applied
- `Flash period` now deafults to `Not specified`