### PR TITLE
Add analytics to both submission forms

### DIFF
--- a/src/submissions/components/MultipleObservationForm.js
+++ b/src/submissions/components/MultipleObservationForm.js
@@ -5,6 +5,7 @@ import { checkJwt } from "../../auth/auth-helpers";
 import { useAuthState } from "../../auth/auth-context";
 import Spinner from "../../app/components/Spinner";
 import CircleCheck from "../../assets/CircleCheck.svg";
+import ReactGA from "react-ga";
 
 export default function MultipleObservationForm({
   setShowSingleObservationForm
@@ -36,8 +37,18 @@ export default function MultipleObservationForm({
 
       if (result.data.success !== 0) {
         setSuccessCount(result.data.success);
+        ReactGA.event({
+          category: "Submissions",
+          action: "User clicked submit on MultipleObservationForm",
+          label: "Submission Success"
+        });
       } else if (result.data.error_messages.length !== 0) {
         setErrorMessages(result.data.error_messages);
+        ReactGA.event({
+          category: "Submissions",
+          action: "User clicked submit on MultipleObservationForm",
+          label: "Submission Failure"
+        });
       }
     } catch (error) {
       setIsError(true);

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -15,6 +15,7 @@ import ConditionFair from "../../assets/ConditionFair.svg";
 import ConditionPoor from "../../assets/ConditionPoor.svg";
 import ConditionBad from "../../assets/ConditionBad.svg";
 import ConditionTerrible from "../../assets/ConditionTerrible.svg";
+import ReactGA from "react-ga";
 
 export default function SingleObservationForm({
   setShowSingleObservationForm
@@ -370,8 +371,18 @@ export default function SingleObservationForm({
 
         if (result.data.success !== 0) {
           setSuccessCount(result.data.success);
+          ReactGA.event({
+            category: "Submissions",
+            action: "User clicked submit on SingleObservationForm",
+            label: "Submission Success"
+          });
         } else if (result.data.error_messages.length !== 0) {
           setErrorMessages(result.data.error_messages);
+          ReactGA.event({
+            category: "Submissions",
+            action: "User clicked submit on SingleObservationForm",
+            label: "Submission Failure"
+          });
         }
       } catch (error) {
         setIsError(true);


### PR DESCRIPTION
- Will track if a user clicked `Submit` on both the `MultipleObservationForm` and `SingleObservationForm`
- Will track if attempted submission was a `success` or `failure` utilizing the error messages returned from the `/submitObservation` endpoint