### PR TITLE
Feature/single iod form

### DIFF
--- a/src/app/app-styles.scss
+++ b/src/app/app-styles.scss
@@ -675,7 +675,7 @@ COPY TEXT
 }
 
 .app__success-message {
-  color: $tertiary-color;
+  color: $primary-text-color;
 }
 
 /* ----------

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -57,9 +57,9 @@ export default function SingleObservationForm({
     `  `
   );
   const [flashPeriod, setFlashPeriod] = useState(`      `); // 6 chars
-  const [remarks, setRemarks] = useState("");
+  const [remarks, setRemarks] = useState(``);
   // IOD STRING
-  const [IOD, setIOD] = useState("");
+  const [IOD, setIOD] = useState(``);
   // VALIDATION ERROR MESSAGING
   const numRegEx = /^\d+$/; // checks if string only contains numbers
   const [isStationError, setIsStationError] = useState(false);
@@ -75,15 +75,14 @@ export default function SingleObservationForm({
     isDeclinationOrElevationError,
     setIsDeclinationOrElevationError
   ] = useState(false);
-
   // SUBMISSION UI STATES
   const [showSubmitButton, setShowSubmitButton] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  // server provides a count of accepted IODs - i.e. correct format and not duplicates
+  // server provides success and error messages upon submissions which are displayed in UI
   const [successCount, setSuccessCount] = useState(null);
-  // server provides these so we can render more specific error messages
   const [errorMessages, setErrorMessages] = useState([]);
   const { jwt } = useAuthState();
+  // set to true if attempt to submit fails
   const [isError, setIsError] = useState(false);
 
   // Builds the IOD string
@@ -364,6 +363,10 @@ export default function SingleObservationForm({
       !isDeclinationOrElevationError
     ) {
       try {
+        console.log(
+          `IOD submitted = -${IOD}- which is ${IOD.length} chars long`
+        );
+
         const result = await axios.post(
           `${API_ROOT}/submitObservation`,
           JSON.stringify({ jwt: jwt, multiple: IOD })

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -55,7 +55,7 @@ export default function SingleObservationForm({
   const [visualMagnitude, setVisualMagnitude] = useState(`   `); // 3 chars
   const [visualMagnitudeUncertainty, setVisualMagnitudeUncertainty] = useState(
     `  `
-  );
+  ); // 2 chars
   const [flashPeriod, setFlashPeriod] = useState(`      `); // 6 chars
   const [remarks, setRemarks] = useState(``);
   // IOD STRING
@@ -110,6 +110,40 @@ export default function SingleObservationForm({
     flashPeriod
   ]);
 
+  // return all the 'default values'
+  const resetFormVariables = () => {
+    setStation(``); // 4 chars
+    setCloudedOut(false);
+    setObserverUnavailable(false);
+    setDate(``); // 8 chars
+    setTime(`         `); // 9 chars
+    setTimeUncertainty(`18`); // 2 chars
+    setConditions(` `); // 1 char
+    setObject(``); // 15 chars
+    setTimeUncertainty(`18`);
+    setAngleFormatCode(`2`);
+    setEpochCode(`5`);
+    setDeclinationOrElevationSign(`+`);
+    setPositionalUncertainty(`18`);
+    setIsHiddenInputs(false);
+    setObjectSearchTerm(``);
+    setObject(``);
+    setObjectSearchResults([]);
+    setAngleFormatCode(`2`);
+    setEpochCode(`5`);
+    setRightAscensionOrAzimuth(`       `); // 7 chars
+    setDeclinationOrElevationSign(`+`);
+    setDeclinationOrElevation(`      `); // 6 chars
+    setPositionalUncertainty(`18`); // 2 chars
+    setBehavior(` `); // 1 char
+    setShowBehaviorOptions(false);
+    setVisualMagnitudeSign(` `); // 1 char
+    setVisualMagnitude(`   `);
+    setVisualMagnitudeUncertainty(`  `); // 2 chars
+    setFlashPeriod(`      `); // 6 chars
+    setRemarks(``);
+  };
+
   // Updates IOD when user toggles `Clouded Out` or `Observer Unavailable`
   useEffect(() => {
     if (conditions === "C" || conditions === "O") {
@@ -121,18 +155,8 @@ export default function SingleObservationForm({
       setDeclinationOrElevationSign(` `); // 1 char
       setPositionalUncertainty(`  `); // 2 chars
       setVisualMagnitudeSign(` `); // 1 char
-      setVisualMagnitudeUncertainty(`  `); // 2 chars
     } else {
-      setIsHiddenInputs(false); // shows all inputs again
-      // return all the 'default values' when user deselects either C or O
-      setObject(``); // 15 chars
-      setTimeUncertainty(`18`);
-      setAngleFormatCode(`2`);
-      setEpochCode(`5`);
-      setDeclinationOrElevationSign(`+`);
-      setPositionalUncertainty(`18`);
-      setVisualMagnitudeSign(`+`);
-      setVisualMagnitudeUncertainty(`10`);
+      resetFormVariables();
     }
   }, [conditions]);
 
@@ -363,10 +387,6 @@ export default function SingleObservationForm({
       !isDeclinationOrElevationError
     ) {
       try {
-        console.log(
-          `IOD submitted = -${IOD}- which is ${IOD.length} chars long`
-        );
-
         const result = await axios.post(
           `${API_ROOT}/submitObservation`,
           JSON.stringify({ jwt: jwt, multiple: IOD })
@@ -379,6 +399,7 @@ export default function SingleObservationForm({
             action: "User clicked submit on SingleObservationForm",
             label: "Submission Success"
           });
+          resetFormVariables();
         } else if (result.data.error_messages.length !== 0) {
           setErrorMessages(result.data.error_messages);
           ReactGA.event({

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -1191,8 +1191,6 @@ export default function SingleObservationForm({
               }
             >
               {IOD}
-              {` `}
-              {remarks}
             </p>
           </div>
         </div>


### PR DESCRIPTION
- Fixes color of messaging shown in UI after successful submission
- Adds `resetFormVariables` function that is used after a submission is successful, and when the user toggles `clouded out` or `observer unavailable` on and off
- Removes the remarks from the box above the submit button that contains the IOD. The remarks are still included in the submission, just not rendered after the IOD in that section.