### PR TITLE
Feature/single iod form

### DIFF
--- a/src/submissions/components/MultipleObservationForm.js
+++ b/src/submissions/components/MultipleObservationForm.js
@@ -57,23 +57,24 @@ export default function MultipleObservationForm({
   };
 
   return (
-    <form
-      className="multiple-observation-form"
-      onSubmit={event => {
-        event.preventDefault();
-        handleSubmit();
-      }}
-    >
+    <Fragment>
       {jwt === "none" ? (
         <p className="app__error-message">
-          Please log in to submit your observations
+          Please log in to submit your observations!!
         </p>
       ) : null}
-      <div style={{ display: "block" }}>
-        <textarea
-          required
-          className="multiple-observation-form__textarea"
-          placeholder={`Paste your observations in this field, one observation per line like so:
+      <form
+        className="multiple-observation-form"
+        onSubmit={event => {
+          event.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <div style={{ display: "block" }}>
+          <textarea
+            required
+            className="multiple-observation-form__textarea"
+            placeholder={`Paste your observations in this field, one observation per line like so:
           
 12345 98 123A   2007 G 20081122112233444 56 14 1122334+112233 39 S
 12345 98 123A   2007 F 2008112211223344  56 25 1122   +1122   28 R+05  1
@@ -84,69 +85,70 @@ export default function MultipleObservationForm({
 12345 98 123UNK 2007 F 200811221123400   27                      P-010 05  10000
                 2007 O 20081122
                 2007 C 200811231130`}
-          value={pastedIODs}
-          onChange={event => setPastedIODs(event.target.value)}
-          rows="10"
-          cols="80"
-        />
+            value={pastedIODs}
+            onChange={event => setPastedIODs(event.target.value)}
+            rows="10"
+            cols="80"
+          />
 
-        {/* Success message */}
-        {successCount > 0 ? (
-          <div className="app__success-message">
-            <img
-              className="multiple-observation-form__image"
-              src={CircleCheck}
-              alt="check"
-            ></img>
-            Thank you for your submission of {successCount}{" "}
-            {successCount === 1 ? "observation" : "observations"}!
-          </div>
-        ) : null}
+          {/* Success message */}
+          {successCount > 0 ? (
+            <div className="app__success-message">
+              <img
+                className="multiple-observation-form__image"
+                src={CircleCheck}
+                alt="check"
+              ></img>
+              Thank you for your submission of {successCount}{" "}
+              {successCount === 1 ? "observation" : "observations"}!
+            </div>
+          ) : null}
 
-        {/* Failure messages */}
-        {errorMessages.length > 0 ? (
+          {/* Failure messages */}
+          {errorMessages.length > 0 ? (
+            <Fragment>
+              <p className="app__error-message">Something went wrong!</p>
+              {errorMessages.map(message => {
+                return <p className="app__error-message">{message}</p>;
+              })}
+            </Fragment>
+          ) : null}
+        </div>
+
+        {isError ? (
+          <p className="app__error-message">Something went wrong...</p>
+        ) : isLoading ? (
+          <Spinner />
+        ) : (
           <Fragment>
-            <p className="app__error-message">Something went wrong!</p>
-            {errorMessages.map(message => {
-              return <p className="app__error-message">{message}</p>;
-            })}
-          </Fragment>
-        ) : null}
-      </div>
-
-      {isError ? (
-        <p className="app__error-message">Something went wrong...</p>
-      ) : isLoading ? (
-        <Spinner />
-      ) : (
-        <Fragment>
-          <div className="multiple-observation-form__button-wrapper">
-            <span
-              className="submit__single-observation-nav-button app__hide-on-mobile app__hide-on-tablet"
-              onClick={() => setShowSingleObservationForm(true)}
-            >
-              Or enter individual observation
-            </span>
-
-            {jwt === "none" ? null : (
-              <button
-                type="submit"
-                className="submit__submit-button"
-                style={pastedIODs ? { opacity: "1" } : { opacity: "0.5" }}
+            <div className="multiple-observation-form__button-wrapper">
+              <span
+                className="submit__single-observation-nav-button app__hide-on-mobile app__hide-on-tablet"
+                onClick={() => setShowSingleObservationForm(true)}
               >
-                SUBMIT
-              </button>
+                Or enter individual observation
+              </span>
+
+              {jwt === "none" ? null : (
+                <button
+                  type="submit"
+                  className="submit__submit-button"
+                  style={pastedIODs ? { opacity: "1" } : { opacity: "0.5" }}
+                >
+                  SUBMIT
+                </button>
+              )}
+            </div>
+            {jwt === "none" ? null : (
+              <p className="submit__submit-warning">
+                Please keep in mind that this data will be automatically
+                recorded into TruSat's catalog of orbital positions, and
+                factored into orbital predictions for this object.
+              </p>
             )}
-          </div>
-          {jwt === "none" ? null : (
-            <p className="submit__submit-warning">
-              Please keep in mind that this data will be automatically recorded
-              into TruSat's catalog of orbital positions, and factored into
-              orbital predictions for this object.
-            </p>
-          )}
-        </Fragment>
-      )}
-    </form>
+          </Fragment>
+        )}
+      </form>
+    </Fragment>
   );
 }

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -232,6 +232,7 @@ export default function SingleObservationForm({
 
     // if rightAscensionOrAzimuth contains non-whitespace chars or is not 9 chars long
     if (
+      declinationOrElevationSign !== ` ` ||
       /\S/.test(rightAscensionOrAzimuth) ||
       rightAscensionOrAzimuth.length !== 7
     ) {
@@ -250,6 +251,7 @@ export default function SingleObservationForm({
 
     // if declinationOrElevation contains non-whitespace chars or is not 9 chars long
     if (
+      declinationOrElevationSign !== ` ` ||
       /\S/.test(declinationOrElevation) ||
       declinationOrElevation.length !== 6
     ) {
@@ -272,6 +274,7 @@ export default function SingleObservationForm({
     numRegEx,
     object,
     rightAscensionOrAzimuth,
+    declinationOrElevationSign,
     declinationOrElevation
   ]);
 
@@ -924,7 +927,7 @@ export default function SingleObservationForm({
                     }
                     style={
                       isRightAscensionOrAzimuthError
-                        ? { border: "2px solid red" }
+                        ? { border: "2px solid #FC7756" }
                         : null
                     }
                   />
@@ -961,8 +964,9 @@ export default function SingleObservationForm({
                       }
                       value={declinationOrElevationSign}
                     >
-                      <option value="+">+</option>
-                      <option value="-">-</option>
+                      <option value={` `}>N/A</option>
+                      <option value={`+`}>+</option>
+                      <option value={`-`}>-</option>
                     </select>
                     <input
                       className="app__form__input object-position__declination-elevation"
@@ -993,7 +997,7 @@ export default function SingleObservationForm({
                       }
                       style={
                         isDeclinationOrElevationError
-                          ? { border: "2px solid red" }
+                          ? { border: "2px solid #FC7756" }
                           : null
                       }
                     />

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -172,7 +172,7 @@ export default function SingleObservationForm({
   useEffect(() => {
     if (date.length === 8) {
       const todayDate = new Date(); // get todays date
-      const todayTimeStamp = todayDate.getTime();
+      const tomorrowTimeStamp = todayDate.getTime() + 86400000;
       // convert date and time inputs to format readable by Date object
       // uses midnight for time if user hasn't added a time value
       const observationDateTime = new Date(
@@ -187,7 +187,7 @@ export default function SingleObservationForm({
       // TODO - add additional check to reject observations from too long ago
       const observationTimeStamp = observationDateTime.getTime();
 
-      if (observationTimeStamp > todayTimeStamp) {
+      if (observationTimeStamp > tomorrowTimeStamp) {
         setIsDateAndTimeError(true); // date of observation is after current time
       } else {
         setIsDateAndTimeError(false); // date of observation is before current time

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -138,7 +138,7 @@ export default function SingleObservationForm({
     setBehavior(` `); // 1 char
     setShowBehaviorOptions(false);
     setVisualMagnitudeSign(` `); // 1 char
-    setVisualMagnitude(`   `);
+    setVisualMagnitude(`   `); // 3 chars
     setVisualMagnitudeUncertainty(`  `); // 2 chars
     setFlashPeriod(`      `); // 6 chars
     setRemarks(``);
@@ -157,8 +157,13 @@ export default function SingleObservationForm({
       setDeclinationOrElevationSign(` `); // 1 char
       setDeclinationOrElevation(`      `); // 6 chars
       setPositionalUncertainty(`  `); // 2 chars
+      setBehavior(` `); // 1 char
       setVisualMagnitudeSign(` `); // 1 char
+      setVisualMagnitude(`   `); // 3 chars
+      setVisualMagnitudeUncertainty(`  `); // 2 chars
+      setFlashPeriod(`      `); // 6 chars
     } else {
+      setObject(``); // 15 chars
       setIsHiddenInputs(false); // show relevant inputs when 'C' or 'O' is toggled off
     }
   }, [conditions]);

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -422,7 +422,10 @@ export default function SingleObservationForm({
       } catch (error) {
         setIsError(true);
       }
+    } else {
+      alert(`Please clear all errors in the form and try again`);
     }
+
     setIsLoading(false);
   };
 

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -152,11 +152,14 @@ export default function SingleObservationForm({
       setTimeUncertainty(`  `); // 2 chars
       setAngleFormatCode(` `); // 1 char
       setEpochCode(` `); // 1 char
+      setDeclinationOrElevation();
+      setRightAscensionOrAzimuth(`       `); // 7 chars
       setDeclinationOrElevationSign(` `); // 1 char
+      setDeclinationOrElevation(`      `); // 6 chars
       setPositionalUncertainty(`  `); // 2 chars
       setVisualMagnitudeSign(` `); // 1 char
     } else {
-      resetFormVariables();
+      setIsHiddenInputs(false); // show relevant inputs when 'C' or 'O' is toggled off
     }
   }, [conditions]);
 

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -964,7 +964,7 @@ export default function SingleObservationForm({
                       }
                       value={declinationOrElevationSign}
                     >
-                      <option value={` `}>N/A</option>
+                      <option value={` `}>?</option>
                       <option value={`+`}>+</option>
                       <option value={`-`}>-</option>
                     </select>

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -110,7 +110,7 @@ export default function SingleObservationForm({
     flashPeriod
   ]);
 
-  // return all the 'default values'
+  //  return all the 'default values' upon submit
   const resetFormVariables = () => {
     setStation(``); // 4 chars
     setCloudedOut(false);
@@ -163,7 +163,7 @@ export default function SingleObservationForm({
       setVisualMagnitudeUncertainty(`  `); // 2 chars
       setFlashPeriod(`      `); // 6 chars
     } else {
-      setObject(``); // 15 chars
+      setObject(``);
       setIsHiddenInputs(false); // show relevant inputs when 'C' or 'O' is toggled off
     }
   }, [conditions]);

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -430,7 +430,7 @@ export default function SingleObservationForm({
     <Fragment>
       {jwt === "none" ? (
         <p className="app__error-message">
-          Please log in to submit your observations
+          Please log in to submit your observations!!
         </p>
       ) : null}
       <form

--- a/src/views/Submit.js
+++ b/src/views/Submit.js
@@ -3,16 +3,17 @@ import { NavLink } from "react-router-dom";
 import MultipleObservationForm from "../submissions/components/MultipleObservationForm";
 import SingleObservationForm from "../submissions/components/SingleObservationForm";
 import { emails } from "../app/app-helpers";
+import { useAuthState } from "../auth/auth-context";
 
 export default function Submit() {
   const [showSingleObservationForm, setShowSingleObservationForm] = useState(
     false
   );
+  const { jwt } = useAuthState();
 
   return (
     <div className="submit__wrapper">
       <h1 className="submit__header">Submit Observations</h1>
-
       {showSingleObservationForm ? (
         <Fragment>
           <h2 className="submit__sub-header">

--- a/src/views/Submit.js
+++ b/src/views/Submit.js
@@ -3,13 +3,11 @@ import { NavLink } from "react-router-dom";
 import MultipleObservationForm from "../submissions/components/MultipleObservationForm";
 import SingleObservationForm from "../submissions/components/SingleObservationForm";
 import { emails } from "../app/app-helpers";
-import { useAuthState } from "../auth/auth-context";
 
 export default function Submit() {
   const [showSingleObservationForm, setShowSingleObservationForm] = useState(
     false
   );
-  const { jwt } = useAuthState();
 
   return (
     <div className="submit__wrapper">


### PR DESCRIPTION
closes #169 
- Choosing `Clouded Out` or `Observer Unavailable` now clears all values from the form that have been previously entered and are now N/A
- Error messaging to prompt user to enter values for `Right Ascension/Declination` or `Azimuth/Elevation` now render in the UI if a value of `+` or `-` is chosen in the form for `declinationOrElevationSign`. Therefore these errors will render by default as `+` is the default value selected for the sign.
- A simple alert is now thrown in the UI if the user clicks the `submit` button when there is still input error messaging present in the UI
- The date field now accommodates submissions for date that are 24 hours ahead of their current date/time to accommodate the UTC requirement
- Both the single and multiple submission forms have `Please log in to submit your observations!!` error messaging rendered above them in the event that the user is not logged in.