### PR TITLE
Feature/single iod form

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -92,7 +92,7 @@ export default function App() {
         <Switch>
           <Route exact path="/" component={Welcome} />
           <Route path="/catalog/:catalogFilter" component={Catalog} />
-          <Route path="/submit/:form" component={Submit} NoMatch={NoMatch} />
+          <Route path="/submit/:form" component={Submit} />
           <Route path="/submit" component={Submit} />
           <Route path="/object/:number" component={ObjectInfo} />
           <Route exact path="/profile/:address" component={Profile} />

--- a/src/App.js
+++ b/src/App.js
@@ -92,6 +92,7 @@ export default function App() {
         <Switch>
           <Route exact path="/" component={Welcome} />
           <Route path="/catalog/:catalogFilter" component={Catalog} />
+          <Route path="/submit/:form" component={Submit} NoMatch={NoMatch} />
           <Route path="/submit" component={Submit} />
           <Route path="/object/:number" component={ObjectInfo} />
           <Route exact path="/profile/:address" component={Profile} />

--- a/src/submissions/components/MultipleObservationForm.js
+++ b/src/submissions/components/MultipleObservationForm.js
@@ -1,4 +1,5 @@
 import React, { useState, Fragment } from "react";
+import { NavLink } from "react-router-dom";
 import axios from "axios";
 import { API_ROOT } from "../../app/app-helpers";
 import { checkJwt } from "../../auth/auth-helpers";
@@ -7,9 +8,7 @@ import Spinner from "../../app/components/Spinner";
 import CircleCheck from "../../assets/CircleCheck.svg";
 import ReactGA from "react-ga";
 
-export default function MultipleObservationForm({
-  setShowSingleObservationForm
-}) {
+export default function MultipleObservationForm() {
   const [isLoading, setIsLoading] = useState(false);
   const [pastedIODs, setPastedIODs] = useState(``);
   // server provides a count of accepted IODs - i.e. correct format and not duplicates
@@ -122,12 +121,11 @@ export default function MultipleObservationForm({
         ) : (
           <Fragment>
             <div className="multiple-observation-form__button-wrapper">
-              <span
-                className="submit__single-observation-nav-button app__hide-on-mobile app__hide-on-tablet"
-                onClick={() => setShowSingleObservationForm(true)}
-              >
-                Or enter individual observation
-              </span>
+              <NavLink className="app__nav-link" to="/submit/single">
+                <span className="submit__single-observation-nav-button app__hide-on-mobile app__hide-on-tablet">
+                  Or enter individual observation
+                </span>
+              </NavLink>
 
               {jwt === "none" ? null : (
                 <button

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -1,4 +1,5 @@
 import React, { useState, Fragment, useEffect } from "react";
+import { NavLink } from "react-router-dom";
 import axios from "axios";
 import { useAuthState } from "../../auth/auth-context";
 import Spinner from "../../app/components/Spinner";
@@ -17,9 +18,7 @@ import ConditionBad from "../../assets/ConditionBad.svg";
 import ConditionTerrible from "../../assets/ConditionTerrible.svg";
 import ReactGA from "react-ga";
 
-export default function SingleObservationForm({
-  setShowSingleObservationForm
-}) {
+export default function SingleObservationForm() {
   // STATION CONDITIONS
   const [station, setStation] = useState(``); // 4 chars
   const [cloudedOut, setCloudedOut] = useState(false);
@@ -1264,12 +1263,11 @@ export default function SingleObservationForm({
         ) : (
           <Fragment>
             <div className="single-observation-form__button-wrapper">
-              <span
-                className="submit__single-observation-nav-button"
-                onClick={() => setShowSingleObservationForm(false)}
-              >
-                Or enter pre-formatted data
-              </span>
+              <NavLink className="app__nav-link" to="/submit">
+                <span className="submit__single-observation-nav-button">
+                  Or enter pre-formatted data
+                </span>
+              </NavLink>
 
               {jwt === "none" ? null : (
                 <button

--- a/src/views/Submit.js
+++ b/src/views/Submit.js
@@ -1,32 +1,20 @@
-import React, { Fragment, useState } from "react";
-import { NavLink } from "react-router-dom";
+import React, { Fragment } from "react";
+import { NavLink, useRouteMatch } from "react-router-dom";
 import MultipleObservationForm from "../submissions/components/MultipleObservationForm";
 import SingleObservationForm from "../submissions/components/SingleObservationForm";
 import { emails } from "../app/app-helpers";
 
 export default function Submit() {
-  const [showSingleObservationForm, setShowSingleObservationForm] = useState(
-    false
-  );
+  const { url } = useRouteMatch();
 
   return (
     <div className="submit__wrapper">
       <h1 className="submit__header">Submit Observations</h1>
-      {showSingleObservationForm ? (
-        <Fragment>
-          <h2 className="submit__sub-header">
-            Enter an individual observation
-          </h2>
-          <SingleObservationForm
-            setShowSingleObservationForm={setShowSingleObservationForm}
-          />
-        </Fragment>
-      ) : (
+      {/* Render multiple submission form */}
+      {url === "/submit" || url === "/submit/multiple" ? (
         <Fragment>
           <h2 className="submit__sub-header">Enter pre-formatted data</h2>
-          <MultipleObservationForm
-            setShowSingleObservationForm={setShowSingleObservationForm}
-          />
+          <MultipleObservationForm />
           <div>
             <p className="submit__text">
               Or submit observations to{" "}
@@ -39,6 +27,19 @@ export default function Submit() {
             </NavLink>
           </div>
         </Fragment>
+      ) : // Render single submission form
+      url === "/submit/single" ? (
+        <Fragment>
+          <h2 className="submit__sub-header">
+            Enter an individual observation
+          </h2>
+          <SingleObservationForm />
+        </Fragment>
+      ) : (
+        <h3 className="app__error-message">
+          <code>{url}</code> is not a route in TruSat. Please check that you
+          entered the correct URL
+        </h3>
       )}
     </div>
   );


### PR DESCRIPTION
Closes #171 

- `/submit/single` route added to bring user to Single IOD submission form 
- Multiple IOD submission form remains the default and will be rendered on visit to `/submit`
- `submit/multiple` can also be used to render Multiple IOD submission form
- Both forms now utilize NavLinks as opposed to the hook previously used to render each form
- When user appends anything other than `/single` or `/multiple` to the `/submit` route an error will be displayed in the UI