### PR TITLE
Update check for expired claim account jwt

### DIFF
--- a/src/views/VerifyClaimAccount.js
+++ b/src/views/VerifyClaimAccount.js
@@ -1,13 +1,14 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import axios from "axios";
 import { NavLink } from "react-router-dom";
 import jwt_decode from "jwt-decode";
-import { checkJwt, createWallet, createSecret } from "../auth/auth-helpers";
+import { createWallet, createSecret } from "../auth/auth-helpers";
 import { API_ROOT } from "../app/app-helpers";
 import { useAuthState, useAuthDispatch } from "../auth/auth-context";
 import Spinner from "../app/components/Spinner";
 
 export default function VerifyClaimAccount({ match }) {
+  const [isExpired, setIsExpired] = useState(false);
   const [password, setPassword] = useState("");
   const [retypedPassword, setRetypedPassword] = useState("");
   const [showInvalidPasswordError, setShowInvalidPasswordError] = useState(
@@ -22,6 +23,22 @@ export default function VerifyClaimAccount({ match }) {
   const [isSuccess, setIsSuccess] = useState(false);
   const { userAddress } = useAuthState();
   const authDispatch = useAuthDispatch();
+
+  useEffect(() => {
+    const getExpiry = async () => {
+      // get expiry timestamp for jwt and current timestamp
+      const { exp } = await jwt_decode(match.params.jwt);
+      const currentTimestamp = Math.floor(Date.now() / 1000);
+
+      if (currentTimestamp > exp) {
+        setIsExpired(true);
+      }
+
+      console.log(isExpired);
+    };
+
+    getExpiry();
+  }, [match.params.jwt, isExpired]);
 
   const inputsAreValid = () => {
     setShowInvalidPasswordError(false);
@@ -52,9 +69,6 @@ export default function VerifyClaimAccount({ match }) {
     setIsError(false);
 
     if (inputsAreValid()) {
-      // checks if jwt in url is valid and hasn't expired
-      checkJwt(match.params.jwt);
-
       const wallet = createWallet();
       const secret = createSecret(wallet.signingKey.privateKey, password);
 
@@ -86,8 +100,10 @@ export default function VerifyClaimAccount({ match }) {
   ) : (
     <div className="verify-claim-account__wrapper">
       <h1 className="verify-claim-account__header">Verify Claimed Account</h1>
-      {/* Don't show the form when user has successfully claimed, i.e. they received an email containing a secret */}
-      {!isSuccess ? (
+      {/* Don't show the form when user has successfully claimed, i.e. they received an email containing a secret 
+      Or if JWT has expired after 24 hours
+      */}
+      {!isSuccess && !isExpired ? (
         <form
           className="app__form"
           onSubmit={event => {
@@ -139,10 +155,27 @@ export default function VerifyClaimAccount({ match }) {
             </div>
           ) : null}
 
-          <button type="submit" className="app__white-button--small">
-            Submit
-          </button>
+          {isExpired ? null : (
+            <button type="submit" className="app__white-button--small">
+              Submit
+            </button>
+          )}
         </form>
+      ) : null}
+
+      {isExpired ? (
+        <div>
+          <p className="claim-account__message">
+            You waited more than 24 hours to complete the claim account process.
+            Please start the process over again by returning to{" "}
+            <NavLink to="/claim" className="app__nav-link app__link">
+              here
+            </NavLink>
+            {` `}
+            and make sure to disregard all previous "claim account" emails you
+            may have received.
+          </p>
+        </div>
       ) : null}
 
       {isSuccess ? (


### PR DESCRIPTION
- When claim route is hit and an appended JWT is found, the component now checks if the JWT has expired
- If it has, then the form to reset the users password is hidden and the following message in rendered in the UI:

```
You waited more than 24 hours to complete the claim account process. Please start the process over again by returning to here and make sure to disregard all previous "claim account" emails you may have received.
```
- `here` text is a NavLink component and brings the user back to the `/claim` route to restart the claim account process.
