### PR TITLE
Hotfix to improve messaging of claim account user flow

### DIFF
--- a/src/views/VerifyClaimAccount.js
+++ b/src/views/VerifyClaimAccount.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import axios from "axios";
 import { NavLink } from "react-router-dom";
 import jwt_decode from "jwt-decode";
-import { createWallet, createSecret } from "../auth/auth-helpers";
+import { checkJwt, createWallet, createSecret } from "../auth/auth-helpers";
 import { API_ROOT } from "../app/app-helpers";
 import { useAuthState, useAuthDispatch } from "../auth/auth-context";
 import Spinner from "../app/components/Spinner";
@@ -52,6 +52,9 @@ export default function VerifyClaimAccount({ match }) {
     setIsError(false);
 
     if (inputsAreValid()) {
+      // checks if jwt in url is valid and hasn't expired
+      checkJwt(match.params.jwt);
+
       const wallet = createWallet();
       const secret = createSecret(wallet.signingKey.privateKey, password);
 

--- a/src/views/VerifyClaimAccount.js
+++ b/src/views/VerifyClaimAccount.js
@@ -33,8 +33,6 @@ export default function VerifyClaimAccount({ match }) {
       if (currentTimestamp > exp) {
         setIsExpired(true);
       }
-
-      console.log(isExpired);
     };
 
     getExpiry();


### PR DESCRIPTION
- Form is now hidden if the users unique JWT has expired (24 hours after they received it) when they try to set a new password
- They now see a message prompting them to restart the process with a link to the `/claim` route