### PR TITLE
Chore/update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,20 @@ And here are some examples:
 
 #### Branch creation to opening a PR
 
-- In command line, checkout the development branch, named “dev” with git checkout dev then git pull to ensure you have the latest development branch on your local machine
-- Referencing the branch naming convention outlined above determine the group and name for your branch then run git checkout -b {group}/{name-of-group} to create the new branch and check it out.
+- In command line, checkout the development branch, named “dev” with `git checkout dev` then `git pull` to ensure you have the latest development branch on your local machine
+- Referencing the branch naming convention outlined above determine the group and name for your branch then run `git checkout -b {group}/{name-of-group}` to create the new branch and check it out.
 - Commit early and commit often with clear and concise comments.
-- Run git push --set-upstream origin <your-new-branch> to add your new branch to the remote repo when you feel the work completed warrants a back up.
-- When ready to open a PR, use git push to add all your latest commits to the remote copy.
+- Run `git push --set-upstream origin <your-new-branch>` to add your new branch to the remote repo when you feel the work completed warrants a back up.
+- When ready to open a PR, use `git push` to add all your latest commits to the remote copy.
 - Do not open a PR without directing it to an open issue on GitHub. If an issue does not exist, create it and add a label. Here's an example:
 
 ```
 The "How To" page content is out of date when compared to the latest communication content found in the TruSat discuss forum
 ```
 
-- When ready click the green `New pull request` button on the `Pull requests` page for the repo on GitHub, making sure you are requesting to merge your branch into the development branch, and not master. The only branches that can open a PR to the “master” branch are those grouped as “hotfix”(or “dev”, which will be handled by the core contributors during a team review process)
+- When ready click the green "New pull request" button on the "Pull requests" page for the repo on GitHub, making sure you are requesting to merge your branch into the development branch, and not master. The only branches that can open a PR to the “master” branch are those grouped as “hotfix” or “dev”.
 - Assign at least one reviewer to your PR.
-- Add detailed comments as to what your PR achieves and make sure to reference the issue that will be closed by this PR by utilizing the number of the issue it will close. Bulleted lists are preferred. Eg:
+- Add detailed comments to outline what your PR achieves and make sure to reference the issue that will be closed by this PR by utilizing the issue number. Bulleted lists are preferred. For example:
 
 ```
 - Updates the “how to” view with the latest comms content

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 TruSat is an open-source space sustainability tool created by the team at [ConsenSys Space](https://consensys.space). Check out the project [here](https://trusat.org).
 
+![TruSat banner](https://trusat-assets.s3.amazonaws.com/readme-banner.jpg)
+
 ## Get Started
 
 This repo was bootstrapped with [create-react-app](https://github.com/facebook/create-react-app). To get started clone the repo, `cd` into it and run the following commands:
@@ -49,7 +51,7 @@ And here are some examples:
 
 - In command line, checkout the development branch, named “dev” with `git checkout dev` then `git pull` to ensure you have the latest development branch on your local machine
 - Referencing the branch naming convention outlined above determine the group and name for your branch then run `git checkout -b {group}/{name-of-group}` to create the new branch and check it out.
-- Commit early and commit often with clear and concise comments.
+- Commit early and commit often with clear and concise comments. All commits should remain focused in scope so try to avoid submitting PR's that contain unrelated commits.
 - Run `git push --set-upstream origin <your-new-branch>` to add your new branch to the remote repo when you feel the work completed warrants a back up.
 - When ready to open a PR, use `git push` to add all your latest commits to the remote copy.
 - Do not open a PR without directing it to an open issue on GitHub. If an issue does not exist, create it and add a label. Here's an example:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+![TruSat banner](https://trusat-assets.s3.amazonaws.com/readme-banner.jpg)
+
 # trusat-frontend
 
-TruSat is an open-source space sustainability tool created by the team at [ConsenSys Space](https://consensys.space). Check out the project [here](https://trusat.org).
-
-![TruSat banner](https://trusat-assets.s3.amazonaws.com/readme-banner.jpg)
+[TruSat](https://trusat.org) is an open-source space sustainability tool created by the team at [ConsenSys Space](https://consensys.space).
 
 ## Get Started
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,39 @@ git checkout --track origin/dev
 yarn install && yarn start
 ```
 
+## Structure
+
+```
+.
+├── LICENSE
+├── README.md
+├── build
+├── firebase.json
+├── node_modules
+├── package.json
+├── public
+│   ├── favicon.ico
+│   ├── index.html
+│   └── manifest.json
+├── src
+│   ├── App.js
+│   ├── App.test.js
+│   ├── app
+│   ├── assets
+│   ├── auth
+│   ├── catalog
+│   ├── index.js
+│   ├── objects
+│   ├── profile
+│   ├── serviceWorker.js
+│   ├── styles
+│   ├── submissions
+│   ├── user
+│   └── views
+├── yarn-error.log
+└── yarn.lock
+```
+
 ## Tests
 
 Run the tests with the following command:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ yarn install && yarn start
 └── yarn.lock
 ```
 
+Inspired by this [post](https://marmelab.com/blog/2015/12/17/react-directory-structure.html), the files in the `src` directory are grouped by domain. For example, within the `submissions` directory you will find all components (and their accompanying styles) related to the domain of observation submissions. At the time of writing this includes the `MultipleObservationForm` and `SingleObservationForm` components.
+
+The `assets` directory contains all the `svg` files that are utilized by the front end. Other image files are hosted externally on AWS.
+
 ## Tests
 
 Run the tests with the following command:

--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ And here are some examples:
 - Commit early and commit often with clear and concise comments.
 - Run git push --set-upstream origin <your-new-branch> to add your new branch to the remote repo when you feel the work completed warrants a back up.
 - When ready to open a PR, use git push to add all your latest commits to the remote copy.
-- Do not open a PR without directing it to an open issue on GitHub. If an issue does not exist, create it and add a label, e.g " For example:
+- Do not open a PR without directing it to an open issue on GitHub. If an issue does not exist, create it and add a label. Here's an example:
 
 ```
-The "How To" page content is out of date when ccompared to the latest communication content found in the TruSat discuss forum”
+The "How To" page content is out of date when compared to the latest communication content found in the TruSat discuss forum
 ```
 
-- When ready click the green `New pull request` button on the `Pull requests` page for the repo on GitHub, making sure you are requesting to merge your branch into the development branch, and not master. The only branches that should request a merge request to the “master” branch are those grouped as “hotfix”(or “dev”, which will be handled by the core contributors)
+- When ready click the green `New pull request` button on the `Pull requests` page for the repo on GitHub, making sure you are requesting to merge your branch into the development branch, and not master. The only branches that can open a PR to the “master” branch are those grouped as “hotfix”(or “dev”, which will be handled by the core contributors during a team review process)
 - Assign at least one reviewer to your PR.
 - Add detailed comments as to what your PR achieves and make sure to reference the issue that will be closed by this PR by utilizing the number of the issue it will close. Bulleted lists are preferred. Eg:
 
 ```
 - Updates the “how to” view with the latest comms content
 - New styles added including a change of font to the headers which matches the latest changes to the "About" page.
-- This closes #32`.
+- This closes #32.
 ```
 
 - Do not open the PR if there are merge conflicts found. Instead - push a fix to your branch that clears the conflicts.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ The "How To" page content is out of date when compared to the latest communicati
 
 - Do not open the PR if there are merge conflicts found. Instead - push a fix to your branch that clears the conflicts.
 - If no merge conflicts are found, open the PR.
+
+## License
+
+TruSat is open source software [licensed as Apache License 2.0](https://github.com/consensys-space/trusat-frontend/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@
 
 ## Get Started
 
-This repo was bootstrapped with [create-react-app](https://github.com/facebook/create-react-app). To get started clone the repo, `cd` into it and run the following commands:
+This repo was bootstrapped with [create-react-app](https://github.com/facebook/create-react-app). You can clone the repo, checkout the `dev` branch, install all the dependencies and run the app in development mode with the following commands in your Terminal:
 
 ```
+git clone https://github.com/consensys-space/trusat-frontend.git trusat-frontend
+cd trusat-frontend
 git checkout --track origin/dev
-
 yarn install && yarn start
 ```
+
+Open http://localhost:3000 to view it in the browser. The page will automatically reload if you make changes to the code.
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -22,4 +22,51 @@ yarn test
 
 ## Contributing
 
-We very much welcome contributions, especially those that tackle open issues. If you wish to contribute, either open an issue then make a pull request or make a pull request against a currently open issue. Check out this [Style Guide](https://github.com/agis/git-style-guide) for some tips on best practices when contributing.
+We very much welcome contributions, especially those that tackle open issues! If you wish to contribute, either open an issue then make a pull request or make a pull request against a currently open issue.
+
+#### Branch naming convention
+
+Our team uses the following convention for naming branches:
+
+- `master` - The production environment
+- `dev` - The branch used for deploying to the development/staging server environment
+- `feature/{name-of-feature}` - A feature branch
+- `bugfix/{name-of-bug-being-fixed}` - Fixing a bug larger in scope than a hotfix
+- `hotfix/{name-of-hotfix}` - Hotfix changes for production issues (branches off master)
+- `chore/{summary-of-chore}` - Cleaning up / organizing the code
+- `wip/{name-of-wip}` - Branched out for some “work in progress” stuff (not ready, can be experimental and you want to keep a remote copy)
+
+And here are some examples:
+
+- `feature/single-iod-form`
+- `feature/single-iod-form-styles`
+- `bugfix/whitepaper-not-rendering-on-ipad`
+- `hotfix/typo-on-welcome-page`
+- `chore/removing-unused-imports`
+- `wip/add-3box-for-authentication`
+
+#### Branch creation to opening a PR
+
+- In command line, checkout the development branch, named “dev” with git checkout dev then git pull to ensure you have the latest development branch on your local machine
+- Referencing the branch naming convention outlined above determine the group and name for your branch then run git checkout -b {group}/{name-of-group} to create the new branch and check it out.
+- Commit early and commit often with clear and concise comments.
+- Run git push --set-upstream origin <your-new-branch> to add your new branch to the remote repo when you feel the work completed warrants a back up.
+- When ready to open a PR, use git push to add all your latest commits to the remote copy.
+- Do not open a PR without directing it to an open issue on GitHub. If an issue does not exist, create it and add a label, e.g " For example:
+
+```
+The "How To" page content is out of date when ccompared to the latest communication content found in the TruSat discuss forum”
+```
+
+- When ready click the green `New pull request` button on the `Pull requests` page for the repo on GitHub, making sure you are requesting to merge your branch into the development branch, and not master. The only branches that should request a merge request to the “master” branch are those grouped as “hotfix”(or “dev”, which will be handled by the core contributors)
+- Assign at least one reviewer to your PR.
+- Add detailed comments as to what your PR achieves and make sure to reference the issue that will be closed by this PR by utilizing the number of the issue it will close. Bulleted lists are preferred. Eg:
+
+```
+- Updates the “how to” view with the latest comms content
+- New styles added including a change of font to the headers which matches the latest changes to the "About" page.
+- This closes #32`.
+```
+
+- Do not open the PR if there are merge conflicts found. Instead - push a fix to your branch that clears the conflicts.
+- If no merge conflicts are found, open the PR.


### PR DESCRIPTION
- Updates the `Get Started` section with detailed Terminal commands to clone and fire up the development environment (while also checking out the `dev` branch)
- Improves README with more information on directory structure 
- Adds a breakdown of process for submitting a PR (including the team branch naming convention), including an example 
- Adds a link to the licence

- closes #193 
- closes #195 