### PR TITLE
Feature/update error handling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,6 +35,7 @@ import Terms from "./views/Terms";
 import SubscriptionConfirmed from "./views/SubscriptionConfirmed";
 import TestPilotConfirmed from "./views/TestPilotConfirmed";
 import ChatIcon from "./app/components/ChatIcon";
+import TestError from "./views/TestError";
 
 export default function App() {
   const authDispatch = useAuthDispatch();
@@ -136,6 +137,7 @@ export default function App() {
               return null;
             }}
           />
+          <Route path="/error" component={TestError}></Route>
           <Route component={NoMatch} />
         </Switch>
 

--- a/src/app/app-helpers.js
+++ b/src/app/app-helpers.js
@@ -40,6 +40,7 @@ export const useTrusatGetApi = () => {
   const [url, setUrl] = useState(``);
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(``);
 
   useEffect(() => {
     let didCancel = false;
@@ -58,6 +59,7 @@ export const useTrusatGetApi = () => {
         console.log(error);
         if (!didCancel) {
           setIsError(true);
+          setErrorMessage(error.toString());
         }
       }
       setIsLoading(false);
@@ -72,7 +74,7 @@ export const useTrusatGetApi = () => {
     };
   }, [url]);
 
-  return [{ data, isLoading, isError }, setUrl];
+  return [{ data, isLoading, isError, errorMessage }, setUrl];
 };
 
 export const useTrusatPostApi = () => {

--- a/src/app/app-helpers.js
+++ b/src/app/app-helpers.js
@@ -75,44 +75,44 @@ export const useTrusatGetApi = () => {
   return [{ data, isLoading, errorMessage }, setUrl];
 };
 
-export const useTrusatPostApi = () => {
-  const [data, setData] = useState([]);
-  const [url, setUrl] = useState(``);
-  const [postData, setPostData] = useState({});
-  const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
+// export const useTrusatPostApi = () => {
+//   const [data, setData] = useState([]);
+//   const [url, setUrl] = useState(``);
+//   const [postData, setPostData] = useState({});
+//   const [isLoading, setIsLoading] = useState(false);
+//   const [isError, setIsError] = useState(false);
 
-  useEffect(() => {
-    let didCancel = false;
+//   useEffect(() => {
+//     let didCancel = false;
 
-    const fetchData = async () => {
-      setIsError(false);
-      setIsLoading(true);
-      try {
-        const result = await axios.post(`${API_ROOT}${url}`, postData);
+//     const fetchData = async () => {
+//       setIsError(false);
+//       setIsLoading(true);
+//       try {
+//         const result = await axios.post(`${API_ROOT}${url}`, postData);
 
-        if (!didCancel) {
-          setData(result.data);
-        }
-      } catch (error) {
-        if (!didCancel) {
-          setIsError(true);
-        }
-      }
-      setIsLoading(false);
-    };
-    // Only fetch when url and postData comes through
-    if (url && postData) {
-      fetchData();
-    }
-    // Clean up function which prevents attempt to update state of unmounted component
-    return () => {
-      didCancel = true;
-    };
-  }, [url, postData]);
+//         if (!didCancel) {
+//           setData(result.data);
+//         }
+//       } catch (error) {
+//         if (!didCancel) {
+//           setIsError(true);
+//         }
+//       }
+//       setIsLoading(false);
+//     };
+//     // Only fetch when url and postData comes through
+//     if (url && postData) {
+//       fetchData();
+//     }
+//     // Clean up function which prevents attempt to update state of unmounted component
+//     return () => {
+//       didCancel = true;
+//     };
+//   }, [url, postData]);
 
-  return [{ data, isLoading, isError }, setUrl, setPostData];
-};
+//   return [{ data, isLoading, isError }, setUrl, setPostData];
+// };
 
 export const renderFlag = code => {
   if (!code) {

--- a/src/app/app-helpers.js
+++ b/src/app/app-helpers.js
@@ -39,14 +39,13 @@ export const useTrusatGetApi = () => {
   const [data, setData] = useState([]);
   const [url, setUrl] = useState(``);
   const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
   const [errorMessage, setErrorMessage] = useState(``);
 
   useEffect(() => {
     let didCancel = false;
 
     const fetchData = async () => {
-      setIsError(false);
+      setErrorMessage(``);
       setIsLoading(true);
 
       try {
@@ -58,7 +57,6 @@ export const useTrusatGetApi = () => {
       } catch (error) {
         console.log(error);
         if (!didCancel) {
-          setIsError(true);
           setErrorMessage(error.toString());
         }
       }
@@ -74,7 +72,7 @@ export const useTrusatGetApi = () => {
     };
   }, [url]);
 
-  return [{ data, isLoading, isError, errorMessage }, setUrl];
+  return [{ data, isLoading, errorMessage }, setUrl];
 };
 
 export const useTrusatPostApi = () => {

--- a/src/catalog/components/CatalogTable.js
+++ b/src/catalog/components/CatalogTable.js
@@ -11,7 +11,7 @@ import {
 import TablePaginator from "../../app/components/TablePaginator";
 
 export default function CatalogTable({ catalogFilter, range, setRange }) {
-  const [{ data, isLoading, isError }, doFetch] = useTrusatGetApi();
+  const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
 
   useEffect(() => {
     doFetch(`/catalog/${catalogFilter}`);
@@ -93,8 +93,10 @@ export default function CatalogTable({ catalogFilter, range, setRange }) {
     <Spinner />
   ) : (
     <Fragment>
-      {isError ? (
-        <p className="app__error-message">Something went wrong ...</p>
+      {errorMessage ? (
+        <p className="app__error-message">
+          Something went wrong... {errorMessage}
+        </p>
       ) : (
         <table className="table">
           <thead className="table__header">

--- a/src/catalog/components/DownloadCatalogFilterTleButton.js
+++ b/src/catalog/components/DownloadCatalogFilterTleButton.js
@@ -5,7 +5,7 @@ import ReactGA from "react-ga";
 
 export default function DownloadCatalogFilterTleButton({ catalogFilter }) {
   const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(``);
   const [textFile, setTextFile] = useState(null);
 
   useEffect(() => {
@@ -13,7 +13,7 @@ export default function DownloadCatalogFilterTleButton({ catalogFilter }) {
   }, [catalogFilter]);
 
   const fetchData = async () => {
-    setIsError(false);
+    setErrorMessage(``);
     setIsLoading(true);
 
     try {
@@ -32,13 +32,13 @@ export default function DownloadCatalogFilterTleButton({ catalogFilter }) {
       }
       setTextFile(window.URL.createObjectURL(dataToDownload));
     } catch (error) {
-      setIsError(true);
+      setErrorMessage(error.toString());
     }
     setIsLoading(false);
   };
 
-  return isError ? (
-    <p className="app__error-message">Something went wrong ...</p>
+  return errorMessage ? (
+    <p className="app__error-message">Something went wrong... {errorMessage}</p>
   ) : isLoading ? (
     <Spinner />
   ) : (

--- a/src/objects/components/InfluenceTable.js
+++ b/src/objects/components/InfluenceTable.js
@@ -13,7 +13,7 @@ import Spinner from "../../app/components/Spinner";
 export default function InfluenceTable() {
   const { noradNumber } = useObjectsState();
   const [range, setRange] = useState({ start: 0, end: 10 });
-  const [{ data, isLoading, isError }, doFetch] = useTrusatGetApi();
+  const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
 
   useEffect(() => {
     if (noradNumber) {
@@ -67,8 +67,8 @@ export default function InfluenceTable() {
     ));
   };
 
-  return isError ? (
-    <p className="app__error-message">Something went wrong...</p>
+  return errorMessage ? (
+    <p className="app__error-message">Something went wrong... {errorMessage}</p>
   ) : isLoading ? (
     <Spinner />
   ) : (

--- a/src/objects/components/Info.js
+++ b/src/objects/components/Info.js
@@ -16,11 +16,7 @@ export default function Info() {
     <React.Fragment>
       {objectInfo.object_name ? null : (
         <p className="object-info__limited-info-message">
-          We have very limited information on this object. This almost certainly
-          means that it is an analyst object. The lack of fidelity may be due to
-          infrequent tracking, cross-tagging (observation association with
-          closely-spaced objects), or inability to associate the object with a
-          known launch.
+          We have very limited information on this object.
         </p>
       )}
       <section className="object-info__header-section-wrapper">

--- a/src/objects/components/Info.js
+++ b/src/objects/components/Info.js
@@ -16,7 +16,7 @@ export default function Info() {
     <React.Fragment>
       {objectInfo.object_name ? null : (
         <p className="object-info__limited-info-message">
-          We have very limited information on this object.
+          The TruSat database has very limited information on this object.
         </p>
       )}
       <section className="object-info__header-section-wrapper">

--- a/src/views/AccountSettings.js
+++ b/src/views/AccountSettings.js
@@ -27,7 +27,7 @@ function UserSettings({ history }) {
   const [newBio, setNewBio] = useState("");
 
   const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(``);
 
   const [newStationData, setNewStationData] = useState([]);
   const [newStationNames, setNewStationNames] = useState({});
@@ -52,7 +52,7 @@ function UserSettings({ history }) {
 
   useEffect(() => {
     const doFetch = async () => {
-      setIsError(false);
+      setErrorMessage(``);
       setIsLoading(true);
       // checks if jwt is valid and hasn't expired
       checkJwt(jwt);
@@ -64,8 +64,7 @@ function UserSettings({ history }) {
 
         profileDispatch({ type: "SET_PROFILE_DATA", payload: result.data });
       } catch (error) {
-        setIsError(true);
-        console.log(error);
+        setErrorMessage(``);
       }
       setIsLoading(false);
     };
@@ -76,7 +75,7 @@ function UserSettings({ history }) {
   }, [jwt, userAddress, profileDispatch]);
 
   const submitEdit = async () => {
-    setIsError(false);
+    setErrorMessage(``);
     setIsLoading(true);
     // checks if jwt is valid and hasn't expired
     checkJwt(jwt);
@@ -99,7 +98,7 @@ function UserSettings({ history }) {
       // refresh the page to pull the latest data just posted
       window.location.reload();
     } catch (error) {
-      setIsError(true);
+      setErrorMessage(error.toString());
     }
   };
 
@@ -110,8 +109,8 @@ function UserSettings({ history }) {
     window.location.reload();
   };
 
-  return isError ? (
-    <p className="app__error-message">Something went wrong...</p>
+  return errorMessage ? (
+    <p className="app__error-message">Something went wrong... {errorMessage}</p>
   ) : isLoading ? (
     <Spinner />
   ) : jwt === "none" ? (

--- a/src/views/AddStation.js
+++ b/src/views/AddStation.js
@@ -18,8 +18,7 @@ export default function AddStation() {
   // submission state
   const [isLoading, setIsLoading] = useState(false);
   const [successfullyAddedStation, setSuccessfullyAddedStation] = useState(``);
-  const [errors, setErrors] = useState([]);
-  const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(``);
 
   const resetFormValues = () => {
     setStationName(``);
@@ -30,7 +29,7 @@ export default function AddStation() {
   };
 
   const submitLocation = async () => {
-    setIsError(false);
+    setErrorMessage(``);
     setSuccessfullyAddedStation(``);
     setIsLoading(true);
     // checks if jwt is valid and hasn't expired
@@ -51,8 +50,7 @@ export default function AddStation() {
       console.log(result);
       setSuccessfullyAddedStation(result.data.station_id);
     } catch (error) {
-      console.log(error);
-      setIsError(true);
+      setErrorMessage(error.toString());
     }
     setIsLoading(false);
     resetFormValues();
@@ -176,8 +174,10 @@ export default function AddStation() {
             </div>
           </Fragment>
         ) : null}
-        {isError ? (
-          <p className="app__error-message">Something went wrong...</p>
+        {errorMessage ? (
+          <p className="app__error-message">
+            Something went wrong... {errorMessage}
+          </p>
         ) : null}
         {isLoading ? (
           <Spinner />

--- a/src/views/ClaimAccount.js
+++ b/src/views/ClaimAccount.js
@@ -6,7 +6,7 @@ import Spinner from "../app/components/Spinner";
 export default function ClaimAccount() {
   const [email, setEmail] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(``);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isNotSuccess, setIsNotSuccess] = useState(false);
 
@@ -23,11 +23,11 @@ export default function ClaimAccount() {
         })
       );
 
-      if (response.data.result === true && !isError) {
+      if (response.data.result === true && !errorMessage) {
         setIsSuccess(true);
       }
-    } catch (err) {
-      setIsError(true);
+    } catch (error) {
+      setErrorMessage(error.toString());
     }
     setEmail("");
     setIsLoading(false);
@@ -65,8 +65,10 @@ export default function ClaimAccount() {
           The email you provided does not have an account with TruSat!
         </p>
       ) : null}
-      {isError ? (
-        <p className="app__error-message">Something went wrong...</p>
+      {errorMessage ? (
+        <p className="app__error-message">
+          Something went wrong... {errorMessage}
+        </p>
       ) : null}
     </div>
   );

--- a/src/views/ObjectInfo.js
+++ b/src/views/ObjectInfo.js
@@ -23,7 +23,7 @@ const isValidNumber = number => {
 
 export default function ObjectInfo({ match }) {
   const noradNumber = match.params.number;
-  const [{ data, isLoading, isError }, doFetch] = useTrusatGetApi();
+  const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
   const { observationFilter } = useObjectsState();
   const objectsDispatch = useObjectsDispatch();
   const [isNumberError, setIsNumberError] = useState(false);
@@ -60,8 +60,10 @@ export default function ObjectInfo({ match }) {
     <Spinner />
   ) : (
     <Fragment>
-      {isError ? (
-        <p className="app__error-message">Something went wrong ...</p>
+      {errorMessage ? (
+        <p className="app__error-message">
+          Something went wrong... {errorMessage}
+        </p>
       ) : (
         <div className="object__wrapper">
           <div className="object-observations__filter-table-wrapper">

--- a/src/views/TestError.js
+++ b/src/views/TestError.js
@@ -9,12 +9,15 @@ export default function Error() {
     doFetch
   ] = useTrusatGetApi();
 
+  // const [isLoading, setIsLoading] = useState(false);
   // const [errorMessage, setErrorMessage] = useState(``);
 
   useEffect(() => {
     doFetch(`/errorTest`);
 
     // async function fetchError() {
+    //   setIsLoading(true);
+
     //   try {
     //     const result = await axios.get(`${API_ROOT}/errorTest`);
     //     console.log(`result = `, result);
@@ -22,6 +25,8 @@ export default function Error() {
     //     console.log(`error = `, error);
     //     setErrorMessage(error.toString());
     //   }
+
+    //   setIsLoading(false);
     // }
 
     // fetchError();
@@ -34,7 +39,9 @@ export default function Error() {
         <Spinner />
       ) : errorMessage ? (
         <p className="app__error-message">{errorMessage}</p>
-      ) : null}
+      ) : (
+        <div>Success!</div>
+      )}
     </Fragment>
   );
 }

--- a/src/views/TestError.js
+++ b/src/views/TestError.js
@@ -1,0 +1,40 @@
+import React, { useState, useEffect, Fragment } from "react";
+import axios from "axios";
+import { API_ROOT, useTrusatGetApi } from "../app/app-helpers";
+import Spinner from "../app/components/Spinner";
+
+export default function Error() {
+  const [
+    { data, isLoading, isError, errorMessage },
+    doFetch
+  ] = useTrusatGetApi();
+
+  // const [errorMessage, setErrorMessage] = useState(``);
+
+  useEffect(() => {
+    doFetch(`/errorTest`);
+
+    // async function fetchError() {
+    //   try {
+    //     const result = await axios.get(`${API_ROOT}/errorTest`);
+    //     console.log(`result = `, result);
+    //   } catch (error) {
+    //     console.log(`error = `, error);
+    //     setErrorMessage(error.toString());
+    //   }
+    // }
+
+    // fetchError();
+  }, [doFetch]);
+
+  return (
+    <Fragment>
+      <div>This is a component for testing errors</div>
+      {isLoading ? (
+        <Spinner />
+      ) : errorMessage ? (
+        <p className="app__error-message">{errorMessage}</p>
+      ) : null}
+    </Fragment>
+  );
+}

--- a/src/views/TestError.js
+++ b/src/views/TestError.js
@@ -4,10 +4,7 @@ import { API_ROOT, useTrusatGetApi } from "../app/app-helpers";
 import Spinner from "../app/components/Spinner";
 
 export default function Error() {
-  const [
-    { data, isLoading, isError, errorMessage },
-    doFetch
-  ] = useTrusatGetApi();
+  const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
 
   // const [isLoading, setIsLoading] = useState(false);
   // const [errorMessage, setErrorMessage] = useState(``);

--- a/src/views/VerifyClaimAccount.js
+++ b/src/views/VerifyClaimAccount.js
@@ -19,7 +19,7 @@ export default function VerifyClaimAccount({ match }) {
   );
   const [understandMessage, setUnderstandMessage] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(``);
   const [isSuccess, setIsSuccess] = useState(false);
   const { userAddress } = useAuthState();
   const authDispatch = useAuthDispatch();
@@ -64,7 +64,7 @@ export default function VerifyClaimAccount({ match }) {
   const verifyClaimAccount = async () => {
     setIsLoading(true);
     setIsSuccess(false);
-    setIsError(false);
+    setErrorMessage(``);
 
     if (inputsAreValid()) {
       const wallet = createWallet();
@@ -84,8 +84,8 @@ export default function VerifyClaimAccount({ match }) {
         const { address } = await jwt_decode(response.data.jwt);
         authDispatch({ type: "SET_USER_ADDRESS", payload: address });
         localStorage.setItem("trusat-jwt", response.data.jwt);
-      } catch (err) {
-        setIsError(true);
+      } catch (error) {
+        setErrorMessage(error.toString());
       }
       setPassword("");
       setRetypedPassword("");
@@ -188,8 +188,10 @@ export default function VerifyClaimAccount({ match }) {
           </NavLink>
         </div>
       ) : null}
-      {isError ? (
-        <p className="app__error-message">Something went wrong...</p>
+      {errorMessage ? (
+        <p className="app__error-message">
+          Something went wrong... {errorMessage}
+        </p>
       ) : null}
     </div>
   );


### PR DESCRIPTION
- Adds a route at `/error` and a placeholder component to run tests on `errorTest` endpoint. This should be deleted after testing in `dev` environment.
- Updates the `useTrusatGetApi` helper hook to now return the error message instead of a boolean so that this message can be rendered along with the generic `Something went wrong...` message
- Updates components that utilize the `useTrusatGetApi` helper to render the error messaging returned from failed API calls
- Updates other `axios` get and post requests to render the error messaging returned from failed API calls
- Changes the message appended to the top of the object view for objects in the database for which we do not have a lot of info on to `The TruSat database has very limited information on this object.`
- Comments out the unused `useTrusatPostApi` helper hook as it not being used anywhere in the app currently. This helper should be revisited to determine if it can be used in places where code is repeated.
- closes #179 
