### PR TITLE
Updates to error handling

### DIFF
--- a/src/app/app-helpers.js
+++ b/src/app/app-helpers.js
@@ -32,7 +32,8 @@ export const axiosWithCache = axios.create({
   adapter: cacheAdapterEnhancer(axios.defaults.adapter, {
     enabledByDefault: true,
     cacheFlag: `useCache`
-  })
+  }),
+  withCredentials: true
 });
 
 export const useTrusatGetApi = () => {
@@ -52,12 +53,13 @@ export const useTrusatGetApi = () => {
         const result = await axiosWithCache(`${API_ROOT}${url}`);
 
         if (!didCancel) {
+          console.log(result);
           setData(result.data);
         }
       } catch (error) {
-        console.log(JSON.stringify(error));
         if (!didCancel) {
-          setErrorMessage(error.toString());
+          console.log(error);
+          setErrorMessage(error.response.data);
         }
       }
       setIsLoading(false);

--- a/src/catalog/components/DownloadCatalogFilterTleButton.js
+++ b/src/catalog/components/DownloadCatalogFilterTleButton.js
@@ -32,7 +32,7 @@ export default function DownloadCatalogFilterTleButton({ catalogFilter }) {
       }
       setTextFile(window.URL.createObjectURL(dataToDownload));
     } catch (error) {
-      setErrorMessage(error.toString());
+      setErrorMessage(error.response.data);
     }
     setIsLoading(false);
   };

--- a/src/views/AccountSettings.js
+++ b/src/views/AccountSettings.js
@@ -98,7 +98,7 @@ function UserSettings({ history }) {
       // refresh the page to pull the latest data just posted
       window.location.reload();
     } catch (error) {
-      setErrorMessage(error.toString());
+      setErrorMessage(error.response.data);
     }
   };
 

--- a/src/views/AddStation.js
+++ b/src/views/AddStation.js
@@ -50,7 +50,7 @@ export default function AddStation() {
       console.log(result);
       setSuccessfullyAddedStation(result.data.station_id);
     } catch (error) {
-      setErrorMessage(error.toString());
+      setErrorMessage(error.response.data);
     }
     setIsLoading(false);
     resetFormValues();

--- a/src/views/ClaimAccount.js
+++ b/src/views/ClaimAccount.js
@@ -27,7 +27,7 @@ export default function ClaimAccount() {
         setIsSuccess(true);
       }
     } catch (error) {
-      setErrorMessage(error.toString());
+      setErrorMessage(error.response.data);
     }
     setEmail("");
     setIsLoading(false);

--- a/src/views/TestCookie.js
+++ b/src/views/TestCookie.js
@@ -3,6 +3,25 @@ import { useTrusatGetApi } from "../app/app-helpers";
 import axios from "axios";
 import Spinner from "../app/components/Spinner";
 
+export default function TestCookie() {
+  const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
+
+  useEffect(() => {
+    doFetch(`/cookieMonster`);
+  }, [doFetch]);
+
+  return (
+    <Fragment>
+      <div>This is a component for testing cookies</div>
+      {isLoading ? (
+        <Spinner />
+      ) : errorMessage ? (
+        <p className="app__error-message">{errorMessage}</p>
+      ) : null}
+    </Fragment>
+  );
+}
+
 // export default function TestCookie() {
 //   // const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
 //   const [isLoading, setIsLoading] = useState(false);
@@ -79,22 +98,3 @@ import Spinner from "../app/components/Spinner";
 //     </Fragment>
 //   );
 // }
-
-export default function TestCookie() {
-  const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
-
-  useEffect(() => {
-    doFetch(`/cookieMonster`);
-  }, [doFetch]);
-
-  return (
-    <Fragment>
-      <div>This is a component for testing cookies</div>
-      {isLoading ? (
-        <Spinner />
-      ) : errorMessage ? (
-        <p className="app__error-message">{errorMessage}</p>
-      ) : null}
-    </Fragment>
-  );
-}

--- a/src/views/TestCookie.js
+++ b/src/views/TestCookie.js
@@ -41,7 +41,7 @@ export default function TestCookie() {
 //         console.log(response);
 //       } catch (error) {
 //         console.log(error);
-//         setErrorMessage(error.toString());
+//         setErrorMessage(error.response.data);
 //       }
 //     }
 
@@ -79,7 +79,7 @@ export default function TestCookie() {
 //         console.log(response);
 //       } catch (error) {
 //         console.log(error);
-//         setErrorMessage(error.toString());
+//         setErrorMessage(error.response.data);
 //       }
 //     }
 

--- a/src/views/TestCookie.js
+++ b/src/views/TestCookie.js
@@ -3,32 +3,89 @@ import { useTrusatGetApi } from "../app/app-helpers";
 import axios from "axios";
 import Spinner from "../app/components/Spinner";
 
+// export default function TestCookie() {
+//   // const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
+//   const [isLoading, setIsLoading] = useState(false);
+//   const [errorMessage, setErrorMessage] = useState(``);
+
+//   useEffect(() => {
+//     // doFetch(`/cookieMonster`);
+
+//     async function fetchCookie() {
+//       setIsLoading(true);
+
+//       try {
+//         const response = await axios.get(
+//           `https://api.consensys.space:8080/cookieMonster`,
+//           { withCredentials: true }
+//         );
+//         console.log(response);
+//       } catch (error) {
+//         console.log(error);
+//         setErrorMessage(error.toString());
+//       }
+//     }
+
+//     fetchCookie();
+//     setIsLoading(false);
+//   }, []);
+
+//   return (
+//     <Fragment>
+//       <div>This is a component for testing cookies</div>
+//       {isLoading ? (
+//         <Spinner />
+//       ) : errorMessage ? (
+//         <p className="app__error-message">{errorMessage}</p>
+//       ) : null}
+//     </Fragment>
+//   );
+// }
+
+// export default function TestCookie() {
+//   // const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
+//   const [isLoading, setIsLoading] = useState(false);
+//   const [errorMessage, setErrorMessage] = useState(``);
+
+//   useEffect(() => {
+//     // doFetch(`/cookieMonster`);
+
+//     async function fetchCookie() {
+//       setIsLoading(true);
+
+//       try {
+//         const response = await fetch(
+//           `https://api.consensys.space:8080/cookieMonster`
+//         );
+//         console.log(response);
+//       } catch (error) {
+//         console.log(error);
+//         setErrorMessage(error.toString());
+//       }
+//     }
+
+//     fetchCookie();
+//     setIsLoading(false);
+//   }, []);
+
+//   return (
+//     <Fragment>
+//       <div>This is a component for testing cookies</div>
+//       {isLoading ? (
+//         <Spinner />
+//       ) : errorMessage ? (
+//         <p className="app__error-message">{errorMessage}</p>
+//       ) : null}
+//     </Fragment>
+//   );
+// }
+
 export default function TestCookie() {
-  // const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
-  const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState(``);
+  const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
 
   useEffect(() => {
-    // doFetch(`/cookieMonster`);
-
-    async function fetchCookie() {
-      setIsLoading(true);
-
-      try {
-        const response = await axios.get(
-          `https://api.consensys.space:8080/cookieMonster`,
-          { withCredentials: true }
-        );
-        console.log(response);
-      } catch (error) {
-        console.log(error);
-        setErrorMessage(error.toString());
-      }
-    }
-
-    fetchCookie();
-    setIsLoading(false);
-  }, []);
+    doFetch(`/cookieMonster`);
+  }, [doFetch]);
 
   return (
     <Fragment>
@@ -37,9 +94,7 @@ export default function TestCookie() {
         <Spinner />
       ) : errorMessage ? (
         <p className="app__error-message">{errorMessage}</p>
-      ) : (
-        <p>API call was succesful</p>
-      )}
+      ) : null}
     </Fragment>
   );
 }

--- a/src/views/TestError.js
+++ b/src/views/TestError.js
@@ -3,31 +3,95 @@ import { useTrusatGetApi } from "../app/app-helpers";
 import axios from "axios";
 import Spinner from "../app/components/Spinner";
 
+// ----------
+// FETCH
+// ----------
+
+// export default function TestError() {
+//   const [isLoading, setIsLoading] = useState(false);
+//   const [errorMessage, setErrorMessage] = useState(``);
+
+//   useEffect(() => {
+//     async function fetchErrorMessage() {
+//       setIsLoading(true);
+
+//       try {
+//         const response = await fetch(
+//           `https://api.consensys.space:8080/errorTest`
+//         );
+//         console.log(`fetch success = `, response);
+//       } catch (error) {
+//         console.log(`fetch error = `, JSON.stringify(error));
+//         setErrorMessage(error.toString());
+//       }
+//     }
+
+//     fetchErrorMessage();
+//     setIsLoading(false);
+//   }, []);
+
+//   return (
+//     <Fragment>
+//       <div>This is a component for testing error messaging</div>
+//       {isLoading ? (
+//         <Spinner />
+//       ) : errorMessage ? (
+//         <p className="app__error-message">{errorMessage}</p>
+//       ) : null}
+//     </Fragment>
+//   );
+// }
+
+// ----------
+// AXIOS CALL
+// ----------
+
+// export default function TestError() {
+//   const [isLoading, setIsLoading] = useState(false);
+//   const [errorMessage, setErrorMessage] = useState(``);
+
+//   useEffect(() => {
+//     async function fetchErrorMessage() {
+//       setIsLoading(true);
+
+//       try {
+//         const response = await axios.get(
+//           `https://api.consensys.space:8080/errorTest`
+//         );
+//         console.log(`axios success = `, response);
+//       } catch (error) {
+//         console.log(`error = `, error.response.data);
+//         setErrorMessage(error.toString());
+//         console.log(`axios error = `, JSON.stringify(error));
+//       }
+//     }
+
+//     fetchErrorMessage();
+//     setIsLoading(false);
+//   }, []);
+
+//   return (
+//     <Fragment>
+//       <div>This is a component for testing error messaging</div>
+//       {isLoading ? (
+//         <Spinner />
+//       ) : errorMessage ? (
+//         <p className="app__error-message">{errorMessage}</p>
+//       ) : null}
+//     </Fragment>
+//   );
+// }
+
+// ----------
+// AXIOS HOOK
+// ----------
+
 export default function TestError() {
-  // const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
-  const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState(``);
+  const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
 
   useEffect(() => {
-    // doFetch(`/errorTest`);
-
-    async function fetchErrorMessage() {
-      setIsLoading(true);
-
-      try {
-        const response = await axios.get(
-          `https://api.consensys.space:8080/errorTest`
-        );
-        console.log(`response = `, response);
-      } catch (error) {
-        console.log(`error = `, JSON.stringify(error));
-        setErrorMessage(error.toString());
-      }
-    }
-
-    fetchErrorMessage();
-    setIsLoading(false);
-  }, []);
+    doFetch(`/errorTest`);
+  }, [doFetch, errorMessage]);
 
   return (
     <Fragment>
@@ -35,10 +99,8 @@ export default function TestError() {
       {isLoading ? (
         <Spinner />
       ) : errorMessage ? (
-        <p className="app__error-message">{errorMessage}</p>
-      ) : (
-        <p>API call was succesful</p>
-      )}
+        <p className="app__error-message">{errorMessage.error}</p>
+      ) : null}
     </Fragment>
   );
 }

--- a/src/views/TestError.js
+++ b/src/views/TestError.js
@@ -22,7 +22,7 @@ import Spinner from "../app/components/Spinner";
 //         console.log(`fetch success = `, response);
 //       } catch (error) {
 //         console.log(`fetch error = `, JSON.stringify(error));
-//         setErrorMessage(error.toString());
+//         setErrorMessage(error.response.data);
 //       }
 //     }
 
@@ -61,7 +61,7 @@ import Spinner from "../app/components/Spinner";
 //         console.log(`axios success = `, response);
 //       } catch (error) {
 //         console.log(`error = `, error.response.data);
-//         setErrorMessage(error.toString());
+//         setErrorMessage(error.response.data);
 //         console.log(`axios error = `, JSON.stringify(error));
 //       }
 //     }

--- a/src/views/TestError.js
+++ b/src/views/TestError.js
@@ -18,9 +18,9 @@ export default function TestError() {
         const response = await axios.get(
           `https://api.consensys.space:8080/errorTest`
         );
-        console.log(response);
+        console.log(`response = `, response);
       } catch (error) {
-        console.log(error);
+        console.log(`error = `, JSON.stringify(error));
         setErrorMessage(error.toString());
       }
     }
@@ -31,7 +31,7 @@ export default function TestError() {
 
   return (
     <Fragment>
-      <div>This is a component for testing cookies</div>
+      <div>This is a component for testing error messaging</div>
       {isLoading ? (
         <Spinner />
       ) : errorMessage ? (

--- a/src/views/VerifyClaimAccount.js
+++ b/src/views/VerifyClaimAccount.js
@@ -85,7 +85,7 @@ export default function VerifyClaimAccount({ match }) {
         authDispatch({ type: "SET_USER_ADDRESS", payload: address });
         localStorage.setItem("trusat-jwt", response.data.jwt);
       } catch (error) {
-        setErrorMessage(error.toString());
+        setErrorMessage(error.response.data);
       }
       setPassword("");
       setRetypedPassword("");


### PR DESCRIPTION
- Update the `axiosWithCache()` helper to grant access to cookies and can be tested using the temporary `/cookie` route
- Update to the `axiosWithCache()` helper to pull the specific error messages from the server
- Updates to all components that make axios post requests to receive specific error messages
- NOTE - `localhost:3000` is added to the access origin control for these tests, which will impact the dev deployed site. A change to include the dev site in the access origin control header will have to be implemented before these changes will work on the dev site. They are working for local testing for now.