### PR TITLE
Fix error where UI prompts user to add station after submitting

### DIFF
--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -103,7 +103,7 @@ export default function SingleObservationForm() {
       }
     };
     // only do fetch if user is logged in and the form does not already have their stations
-    if (observationStations === `` && jwt !== "none") {
+    if (jwt !== "none") {
       fetchObservationStations();
     }
   }, [jwt, observationStations]);


### PR DESCRIPTION
- closes #208 
- The form will now pull the station codes for the user again after a successful submission and will not prompt the user to add a station again (which was causing a UI error to render)