### PR TITLE
Bugfix/move jwt to cookies

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, Fragment } from "react";
-import jwt_decode from "jwt-decode";
-import { checkJwt } from "./auth/auth-helpers";
+import { checkAuthExpiry } from "./auth/auth-helpers";
 import { setCookies } from "./app/app-helpers";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { useAuthDispatch } from "./auth/auth-context";
@@ -43,18 +42,19 @@ export default function App() {
   const [isBannerOpen, setIsBannerOpen] = useState(true);
 
   useEffect(() => {
-    // get jwt from local storage which is decoded to return the user ethereum address
-    const retrieveJwtAndGetUserData = async () => {
-      const jwt = localStorage.getItem("trusat-jwt");
+    // get login credentials from local storage (address and expiry date for auth)
+    const retrieveLoginCredentials = async () => {
+      const { address, exp } = localStorage.getItem("trusat-login-credentials");
       // checks if jwt is valid and hasn't expired
-      checkJwt(jwt);
+      checkAuthExpiry(exp);
 
-      const { address } = await jwt_decode(jwt);
-
-      authDispatch({ type: "SET_JWT", payload: jwt });
       authDispatch({
         type: "SET_USER_ADDRESS",
         payload: address
+      });
+      authDispatch({
+        type: "SET_AUTH_EXPIRY",
+        payload: exp
       });
     };
 
@@ -71,8 +71,8 @@ export default function App() {
       retrieveCookieChoice();
     }
 
-    if (localStorage.getItem("trusat-jwt")) {
-      retrieveJwtAndGetUserData();
+    if (localStorage.getItem("trusat-login-credentials")) {
+      retrieveLoginCredentials();
     }
   }, [authDispatch]);
 

--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,7 @@ export default function App() {
     // get login credentials from local storage (address and expiry date for auth)
     const retrieveLoginCredentials = async () => {
       const { address, exp } = localStorage.getItem("trusat-login-credentials");
-      // checks if jwt is valid and hasn't expired
+      // checks if expiry date on auth is valid (hasn't expired)
       checkAuthExpiry(exp);
 
       authDispatch({

--- a/src/App.js
+++ b/src/App.js
@@ -44,7 +44,9 @@ export default function App() {
   useEffect(() => {
     // get login credentials from local storage (address and expiry date for auth)
     const retrieveLoginCredentials = async () => {
-      const { address, exp } = localStorage.getItem("trusat-login-credentials");
+      const { address, exp } = JSON.parse(
+        localStorage.getItem("trusat-login-credentials")
+      );
       // checks if expiry date on auth is valid (hasn't expired)
       checkAuthExpiry(exp);
 

--- a/src/app/app-helpers.js
+++ b/src/app/app-helpers.js
@@ -77,45 +77,6 @@ export const useTrusatGetApi = () => {
   return [{ data, isLoading, errorMessage }, setUrl];
 };
 
-// export const useTrusatPostApi = () => {
-//   const [data, setData] = useState([]);
-//   const [url, setUrl] = useState(``);
-//   const [postData, setPostData] = useState({});
-//   const [isLoading, setIsLoading] = useState(false);
-//   const [isError, setIsError] = useState(false);
-
-//   useEffect(() => {
-//     let didCancel = false;
-
-//     const fetchData = async () => {
-//       setIsError(false);
-//       setIsLoading(true);
-//       try {
-//         const result = await axios.post(`${API_ROOT}${url}`, postData);
-
-//         if (!didCancel) {
-//           setData(result.data);
-//         }
-//       } catch (error) {
-//         if (!didCancel) {
-//           setIsError(true);
-//         }
-//       }
-//       setIsLoading(false);
-//     };
-//     // Only fetch when url and postData comes through
-//     if (url && postData) {
-//       fetchData();
-//     }
-//     // Clean up function which prevents attempt to update state of unmounted component
-//     return () => {
-//       didCancel = true;
-//     };
-//   }, [url, postData]);
-
-//   return [{ data, isLoading, isError }, setUrl, setPostData];
-// };
-
 export const renderFlag = code => {
   if (!code) {
     return null;

--- a/src/app/components/NavBar.js
+++ b/src/app/components/NavBar.js
@@ -27,7 +27,7 @@ function NavBar(props) {
 
       <div className="nav-bar__route-link-wrapper">
         {/* // Welcome button only rendered when user is logged out */}
-        {userAddress ? null : (
+        {userAddress !== "none" ? null : (
           <div
             className={
               path === "/"
@@ -74,7 +74,7 @@ function NavBar(props) {
         </div>
 
         {/* // My Profile button only rendered when user is logged in */}
-        {userAddress ? (
+        {userAddress !== "none" ? (
           <div
             className={
               path === `/profile/${userAddress}`
@@ -101,7 +101,7 @@ function NavBar(props) {
         ) : null}
 
         {/* // Whitepaper button only rendered when user is logged out */}
-        {userAddress ? null : (
+        {userAddress !== "none" ? null : (
           <div
             className={
               path === `/whitepaper`
@@ -180,7 +180,7 @@ function NavBar(props) {
 
       <div>
         {/* Show Join button when user is not logged in */}
-        {!userAddress ? (
+        {userAddress === "none" ? (
           <Fragment>
             <NavLink className="app__nav-link nav-bar__log-in-text" to="/login">
               <img className="app__nav__icon" src={IconUser} alt="icon"></img>

--- a/src/auth/auth-context.js
+++ b/src/auth/auth-context.js
@@ -17,6 +17,9 @@ function authReducer(state, action) {
     case "SET_USER_ADDRESS": {
       return { ...state, userAddress: action.payload };
     }
+    case "SET_AUTH_EXPIRY": {
+      return { ...state, authExpiry: action.payload };
+    }
     default: {
       throw new Error(`Unhandle action type: ${action.type}`);
     }
@@ -28,7 +31,8 @@ function AuthProvider({ children }) {
     isAuthenticating: false,
     authType: "",
     jwt: "none",
-    userAddress: ""
+    userAddress: "",
+    authExpiry: ""
   });
 
   return (

--- a/src/auth/auth-context.js
+++ b/src/auth/auth-context.js
@@ -11,9 +11,6 @@ function authReducer(state, action) {
     case "SET_AUTH_TYPE": {
       return { ...state, authType: action.payload };
     }
-    case "SET_JWT": {
-      return { ...state, jwt: action.payload };
-    }
     case "SET_USER_ADDRESS": {
       return { ...state, userAddress: action.payload };
     }
@@ -30,8 +27,7 @@ function AuthProvider({ children }) {
   const [state, dispatch] = React.useReducer(authReducer, {
     isAuthenticating: false,
     authType: "",
-    jwt: "none",
-    userAddress: "",
+    userAddress: "none",
     authExpiry: ""
   });
 

--- a/src/auth/auth-helpers.js
+++ b/src/auth/auth-helpers.js
@@ -126,8 +126,10 @@ export const retrieveLoginCredentials = async ({
         email: email,
         address: address,
         signedMessage: signedMessage.signature
-      })
+      }),
+      { withCredentials: true }
     );
+
     return response.data;
   } catch (error) {
     return false;
@@ -160,7 +162,8 @@ export const retrieveMetamaskLoginCredentials = async ({
       JSON.stringify({
         address: address,
         signedMessage: metamaskSignedMessage
-      })
+      }),
+      { withCredentials: true }
     );
     return response.data;
   } catch (error) {

--- a/src/auth/auth-helpers.js
+++ b/src/auth/auth-helpers.js
@@ -169,18 +169,16 @@ export const retrieveMetamaskLoginCredentials = async ({
   }
 };
 
-export const checkJwt = async jwt => {
-  const { exp } = await jwt_decode(jwt);
-
+export const checkAuthExpiry = async exp => {
   // get UNIX current time
   const currentTime = Math.round(+new Date() / 1000);
   // if jwt is of type string and has not expired, return from the function
   // this allows rest of function calling checkJwt to continue
-  if (typeof jwt === "string" && exp > currentTime) {
+  if (exp > currentTime) {
     return true;
     // otherwise remove jwt from localstorage refresh browser
   } else {
-    localStorage.removeItem("trusat-jwt");
+    localStorage.removeItem("trusat-auth-credentials");
     localStorage.removeItem("trusat-allow-cookies"); // delete their previously chosen option
     window.location.reload();
   }

--- a/src/auth/auth-helpers.js
+++ b/src/auth/auth-helpers.js
@@ -114,10 +114,14 @@ export const signUp = async ({ email, address, signedMessage, secret }) => {
   }
 };
 
-// Used for email/password and burner login
-export const retrieveJwt = async ({ email, address, signedMessage }) => {
+// Used for email/password login
+export const retrieveLoginCredentials = async ({
+  email,
+  address,
+  signedMessage
+}) => {
   try {
-    const result = await axios.post(
+    const response = await axios.post(
       `${API_ROOT}/login`,
       JSON.stringify({
         email: email,
@@ -125,7 +129,7 @@ export const retrieveJwt = async ({ email, address, signedMessage }) => {
         signedMessage: signedMessage.signature
       })
     );
-    return result.data.jwt;
+    return response.data;
   } catch (error) {
     return false;
   }
@@ -147,19 +151,19 @@ export const metamaskSignMessage = async ({ nonce, address }) => {
 };
 
 // used for metamask auth
-export const retrieveMetamaskJwt = async ({
+export const retrieveMetamaskLoginCredentials = async ({
   address,
   metamaskSignedMessage
 }) => {
   try {
-    const result = await axios.post(
+    const response = await axios.post(
       `${API_ROOT}/login`,
       JSON.stringify({
         address: address,
         signedMessage: metamaskSignedMessage
       })
     );
-    return result.data.jwt;
+    return response.data;
   } catch (error) {
     return false;
   }

--- a/src/auth/auth-helpers.js
+++ b/src/auth/auth-helpers.js
@@ -4,7 +4,6 @@ import { ethers } from "ethers";
 import Web3 from "web3";
 import pbkdf2 from "pbkdf2";
 import aesjs from "aes-js";
-import jwt_decode from "jwt-decode";
 const web3 = new Web3(Web3.givenProvider || window.ethereum);
 
 export const createWallet = () => {
@@ -172,11 +171,11 @@ export const retrieveMetamaskLoginCredentials = async ({
 export const checkAuthExpiry = async exp => {
   // get UNIX current time
   const currentTime = Math.round(+new Date() / 1000);
-  // if jwt is of type string and has not expired, return from the function
-  // this allows rest of function calling checkJwt to continue
+  // if auth ahsn't expire return from the function
+  // this allows rest of function calling checkAuthExpiry to continue
   if (exp > currentTime) {
     return true;
-    // otherwise remove jwt from localstorage refresh browser
+    // otherwise remove trusat credentials and cookies from localstorage refresh browser
   } else {
     localStorage.removeItem("trusat-auth-credentials");
     localStorage.removeItem("trusat-allow-cookies"); // delete their previously chosen option

--- a/src/auth/auth-helpers.js
+++ b/src/auth/auth-helpers.js
@@ -171,13 +171,13 @@ export const retrieveMetamaskLoginCredentials = async ({
 export const checkAuthExpiry = async exp => {
   // get UNIX current time
   const currentTime = Math.round(+new Date() / 1000);
-  // if auth ahsn't expire return from the function
-  // this allows rest of function calling checkAuthExpiry to continue
+
+  // if auth hasn't expired return from the function to all rest of function calling checkAuthExpiry to continue
   if (exp > currentTime) {
     return true;
     // otherwise remove trusat credentials and cookies from localstorage refresh browser
   } else {
-    localStorage.removeItem("trusat-auth-credentials");
+    localStorage.removeItem("trusat-login-credentials");
     localStorage.removeItem("trusat-allow-cookies"); // delete their previously chosen option
     window.location.reload();
   }

--- a/src/auth/auth.test.js
+++ b/src/auth/auth.test.js
@@ -6,7 +6,7 @@ import {
   signMessage,
   createSecret,
   decryptSecret,
-  checkJwt
+  checkAuthExpiry
 } from "./auth-helpers";
 
 // Make crypto object used in encryption helpers available to test suite
@@ -116,6 +116,6 @@ describe("Auth helpers", () => {
     const jwt =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhZGRyZXNzIjoiMHgyODRjMGIxNWRlYjIyZDM5Y2VhZDNjMGZjOWRhODNlMzVlYWFjZTM4IiwiZXhwIjoxNTcxMjQ3MzUwfQ.VlihvuVEE8Y6kn73_4pV_K8VlXDpocQouPx09h8GwtvHW_JiexbhPtv5FMZffFcbQ0vAz_VCA3EKFs2Euu-mLUT7GKD0gzcHeM15Noi7BXcobPkiAp18v4uSsi91yse4k6Ff_JG3F5hSUKVKy3CKJisL9uH2gG6jL8jwSQkecOSiAPNwa2kb-26way5nKhcNQVtRkgI9mZqMAqPAc_ivXfNfeJbKmRVG2MEtaUnc-OZvevHPQXvy48QhMZYfDHYasX2HTFZIPC35iErU3rbKTOi5qoCuFtoNfDu-lCjnzwhKguGZikSRUzRWPIn8MzSrjuYJu8fSn8595TkBf1zETA";
 
-    expect(await checkJwt(jwt)).not.toBe(true);
+    expect(await checkAuthExpiry(jwt)).not.toBe(true);
   });
 });

--- a/src/auth/auth.test.js
+++ b/src/auth/auth.test.js
@@ -112,10 +112,9 @@ describe("Auth helpers", () => {
   });
 
   it("Can verify if a JWT is invalid", async () => {
-    // This JWT expired on 10/16/2019
-    const jwt =
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhZGRyZXNzIjoiMHgyODRjMGIxNWRlYjIyZDM5Y2VhZDNjMGZjOWRhODNlMzVlYWFjZTM4IiwiZXhwIjoxNTcxMjQ3MzUwfQ.VlihvuVEE8Y6kn73_4pV_K8VlXDpocQouPx09h8GwtvHW_JiexbhPtv5FMZffFcbQ0vAz_VCA3EKFs2Euu-mLUT7GKD0gzcHeM15Noi7BXcobPkiAp18v4uSsi91yse4k6Ff_JG3F5hSUKVKy3CKJisL9uH2gG6jL8jwSQkecOSiAPNwa2kb-26way5nKhcNQVtRkgI9mZqMAqPAc_ivXfNfeJbKmRVG2MEtaUnc-OZvevHPQXvy48QhMZYfDHYasX2HTFZIPC35iErU3rbKTOi5qoCuFtoNfDu-lCjnzwhKguGZikSRUzRWPIn8MzSrjuYJu8fSn8595TkBf1zETA";
+    // timestamp from Jan 1st 2019 at 1am
+    const exp = "1546304400";
 
-    expect(await checkAuthExpiry(jwt)).not.toBe(true);
+    expect(await checkAuthExpiry(exp)).not.toBe(true);
   });
 });

--- a/src/auth/components/LoginForm.js
+++ b/src/auth/components/LoginForm.js
@@ -61,7 +61,10 @@ export default function LoginForm() {
     });
     authDispatch({ type: "SET_AUTH_TYPE", payload: "email" });
     // add login crednetials to local storage so user will stayed logged in until expiry
-    localStorage.setItem("trusat-login-credentials", loginCredentials);
+    localStorage.setItem(
+      "trusat-login-credentials",
+      JSON.stringify(loginCredentials)
+    );
 
     authDispatch({ type: "AUTHENTICATING", payload: false });
   };

--- a/src/auth/components/LoginForm.js
+++ b/src/auth/components/LoginForm.js
@@ -43,7 +43,7 @@ export default function LoginForm() {
       address: wallet.signingKey.address,
       signedMessage: signedMessage
     });
-    // do not attempt to hit /profile unless a valid jwt is returned from retriveJwt
+    // do not attempt to hit /profile unless auth hasn't expired
     if (!loginCredentials) {
       setIsError(true);
       authDispatch({ type: "AUTHENTICATING", payload: false });
@@ -60,7 +60,7 @@ export default function LoginForm() {
       payload: loginCredentials.exp
     });
     authDispatch({ type: "SET_AUTH_TYPE", payload: "email" });
-    // add jwt to local storage so user will stayed logged in until expiry
+    // add login crednetials to local storage so user will stayed logged in until expiry
     localStorage.setItem("trusat-login-credentials", loginCredentials);
 
     authDispatch({ type: "AUTHENTICATING", payload: false });

--- a/src/auth/components/MetaMask.js
+++ b/src/auth/components/MetaMask.js
@@ -3,7 +3,7 @@ import { useAuthState, useAuthDispatch } from "../auth-context";
 import {
   retrieveNonce,
   metamaskSignMessage,
-  retrieveMetamaskJwt,
+  retrieveMetamaskLoginCredentials,
   handleMetamaskConnect
 } from "../auth-helpers";
 import Web3 from "web3";
@@ -44,16 +44,27 @@ export default function MetaMask({ buttonText, GAEvent }) {
 
     // Only hit /profile endpoint if a signed message is returned from metamaskSignedMessage
     if (typeof metamaskSignedMessage === "string") {
-      const jwt = await retrieveMetamaskJwt({ address, metamaskSignedMessage });
-      // only log user in and add jwt to local storage if jwt is valid
-      if (!jwt) {
+      const metamaskLoginCredentials = await retrieveMetamaskLoginCredentials({
+        address,
+        metamaskSignedMessage
+      });
+      // only log user in and add credentaisl to local storage if credentials are valid
+      if (!metamaskLoginCredentials) {
         setIsError(true);
       } else {
+        // Add address to auth state
         authDispatch({ type: "SET_USER_ADDRESS", payload: address });
-        authDispatch({ type: "SET_JWT", payload: jwt });
+        // Add expiry date of auth to auth state
+        authDispatch({
+          type: "SET_AUTH_EXPIRY",
+          payload: metamaskLoginCredentials.exp
+        });
         authDispatch({ type: "SET_AUTH_TYPE", payload: "metamask" });
-        // Add jwt to local storage
-        localStorage.setItem("trusat-jwt", jwt);
+        // Add login credentials to local storage
+        localStorage.setItem(
+          "trusat-login-credentials",
+          metamaskLoginCredentials
+        );
       }
     } else {
       // When user cancels the sign or there is an error returned from metamaskSignMessage

--- a/src/auth/components/MetaMask.js
+++ b/src/auth/components/MetaMask.js
@@ -63,7 +63,7 @@ export default function MetaMask({ buttonText, GAEvent }) {
         // Add login credentials to local storage
         localStorage.setItem(
           "trusat-login-credentials",
-          metamaskLoginCredentials
+          JSON.stringify(metamaskLoginCredentials)
         );
       }
     } else {

--- a/src/objects/components/UserSightingsTable.js
+++ b/src/objects/components/UserSightingsTable.js
@@ -12,18 +12,18 @@ import TablePaginator from "../../app/components/TablePaginator";
 import Spinner from "../../app/components/Spinner";
 
 export default function UserSightingsTable() {
-  const { jwt, userAddress } = useAuthState();
+  const { userAddress } = useAuthState();
   const { noradNumber, objectOrigin } = useObjectsState();
   const [range, setRange] = useState({ start: 0, end: 10 });
   const [{ isLoading, isError, data }, doFetch] = useTrusatGetApi();
 
   useEffect(() => {
-    if ((noradNumber, jwt, userAddress)) {
+    if ((noradNumber, userAddress)) {
       doFetch(
-        `/object/userSightings?jwt=${jwt}&address=${userAddress}&norad_number=${noradNumber}`
+        `/object/userSightings?address=${userAddress}&norad_number=${noradNumber}`
       );
     }
-  }, [jwt, userAddress, noradNumber, doFetch]);
+  }, [userAddress, noradNumber, doFetch]);
 
   const renderUserSightingsRows = () => {
     const { start, end } = range;

--- a/src/submissions/components/MultipleObservationForm.js
+++ b/src/submissions/components/MultipleObservationForm.js
@@ -30,7 +30,8 @@ export default function MultipleObservationForm() {
     try {
       const result = await axios.post(
         `${API_ROOT}/submitObservation`,
-        JSON.stringify({ multiple: pastedIODs })
+        JSON.stringify({ multiple: pastedIODs }),
+        { withCredentials: true }
       );
       setPastedIODs("");
 

--- a/src/submissions/components/MultipleObservationForm.js
+++ b/src/submissions/components/MultipleObservationForm.js
@@ -15,7 +15,7 @@ export default function MultipleObservationForm() {
   const [successCount, setSuccessCount] = useState(null);
   // server provides these so we can render more specific error messages
   const [errorMessages, setErrorMessages] = useState([]);
-  const { authExpiry } = useAuthState();
+  const { address, authExpiry } = useAuthState();
   const [isError, setIsError] = useState(false);
 
   const handleSubmit = async () => {
@@ -24,7 +24,7 @@ export default function MultipleObservationForm() {
     setSuccessCount(null);
     setErrorMessages([]);
 
-    // check if jwt is valid and hasn't expired before submission
+    // check if users auth session hasn't expired before submission
     await checkAuthExpiry(authExpiry);
 
     try {
@@ -57,7 +57,7 @@ export default function MultipleObservationForm() {
 
   return (
     <Fragment>
-      {jwt === "none" ? (
+      {address === "" ? (
         <p className="app__error-message">
           You need to be logged in to submit your observations.
         </p>
@@ -127,7 +127,7 @@ export default function MultipleObservationForm() {
                 </span>
               </NavLink>
 
-              {jwt === "none" ? null : (
+              {address === "" ? null : (
                 <button
                   type="submit"
                   className="submit__submit-button"
@@ -137,7 +137,7 @@ export default function MultipleObservationForm() {
                 </button>
               )}
             </div>
-            {jwt === "none" ? null : (
+            {address === "none" ? null : (
               <p className="submit__submit-warning">
                 Please keep in mind that this data will be automatically
                 recorded into TruSat's catalog of orbital positions, and

--- a/src/submissions/components/MultipleObservationForm.js
+++ b/src/submissions/components/MultipleObservationForm.js
@@ -2,7 +2,7 @@ import React, { useState, Fragment } from "react";
 import { NavLink } from "react-router-dom";
 import axios from "axios";
 import { API_ROOT } from "../../app/app-helpers";
-import { checkJwt } from "../../auth/auth-helpers";
+import { checkAuthExpiry } from "../../auth/auth-helpers";
 import { useAuthState } from "../../auth/auth-context";
 import Spinner from "../../app/components/Spinner";
 import CircleCheck from "../../assets/CircleCheck.svg";
@@ -15,7 +15,7 @@ export default function MultipleObservationForm() {
   const [successCount, setSuccessCount] = useState(null);
   // server provides these so we can render more specific error messages
   const [errorMessages, setErrorMessages] = useState([]);
-  const { jwt } = useAuthState();
+  const { authExpiry } = useAuthState();
   const [isError, setIsError] = useState(false);
 
   const handleSubmit = async () => {
@@ -25,12 +25,12 @@ export default function MultipleObservationForm() {
     setErrorMessages([]);
 
     // check if jwt is valid and hasn't expired before submission
-    await checkJwt(jwt);
+    await checkAuthExpiry(authExpiry);
 
     try {
       const result = await axios.post(
         `${API_ROOT}/submitObservation`,
-        JSON.stringify({ jwt: jwt, multiple: pastedIODs })
+        JSON.stringify({ multiple: pastedIODs })
       );
       setPastedIODs("");
 

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -89,7 +89,9 @@ export default function SingleObservationForm() {
   useEffect(() => {
     const fetchObservationStations = async () => {
       try {
-        let result = await axios.post(`${API_ROOT}/getObservationStations`);
+        let result = await axios.post(`${API_ROOT}/getObservationStations`, {
+          withCredentials: true
+        });
         // sort stations by most observations
         const sortedStations = result.data.sort(
           (a, b) => b.observation_count - a.observation_count
@@ -374,7 +376,9 @@ export default function SingleObservationForm() {
       !isDeclinationOrElevationError
     ) {
       try {
-        const result = await axios.post(`${API_ROOT}/submitObservation`);
+        const result = await axios.post(`${API_ROOT}/submitObservation`, {
+          withCredentials: true
+        });
 
         if (result.data.success !== 0) {
           setSuccessCount(result.data.success);

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -3,7 +3,7 @@ import { NavLink, Redirect } from "react-router-dom";
 import axios from "axios";
 import { useAuthState } from "../../auth/auth-context";
 import Spinner from "../../app/components/Spinner";
-import { checkJwt } from "../../auth/auth-helpers";
+import { checkAuthExpiry } from "../../auth/auth-helpers";
 import {
   API_ROOT,
   QuestionMarkToolTip,
@@ -76,7 +76,7 @@ export default function SingleObservationForm() {
     setIsDeclinationOrElevationError
   ] = useState(false);
   // SUBMISSION UI STATES
-  const { jwt } = useAuthState(); // used in handleSubmit function
+  const { authExpiry } = useAuthState(); // used in handleSubmit function
   const [showSubmitButton, setShowSubmitButton] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   // server provides success and error messages upon submissions which are displayed in UI
@@ -365,7 +365,7 @@ export default function SingleObservationForm() {
     setSuccessCount(null);
     setErrorMessages([]);
     // check if jwt is valid and hasn't expired before submission
-    await checkJwt(jwt);
+    await checkAuthExpiry(authExpiry);
     // Only submit IOD if no validation errors found
     if (
       !isStationError &&

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -76,7 +76,7 @@ export default function SingleObservationForm() {
     setIsDeclinationOrElevationError
   ] = useState(false);
   // SUBMISSION UI STATES
-  const { authExpiry } = useAuthState(); // used in handleSubmit function
+  const { userAddress, authExpiry } = useAuthState(); // used in handleSubmit function
   const [showSubmitButton, setShowSubmitButton] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   // server provides success and error messages upon submissions which are displayed in UI
@@ -89,10 +89,7 @@ export default function SingleObservationForm() {
   useEffect(() => {
     const fetchObservationStations = async () => {
       try {
-        let result = await axios.post(
-          `${API_ROOT}/getObservationStations`,
-          JSON.stringify({ jwt: jwt })
-        );
+        let result = await axios.post(`${API_ROOT}/getObservationStations`);
         // sort stations by most observations
         const sortedStations = result.data.sort(
           (a, b) => b.observation_count - a.observation_count
@@ -103,10 +100,10 @@ export default function SingleObservationForm() {
       }
     };
     // only do fetch if user is logged in and the form does not already have their stations
-    if (jwt !== "none") {
+    if (userAddress !== "") {
       fetchObservationStations();
     }
-  }, [jwt, observationStations]);
+  }, [userAddress, observationStations]);
 
   // Builds the IOD string
   useEffect(() => {
@@ -364,7 +361,7 @@ export default function SingleObservationForm() {
     setIsError(false);
     setSuccessCount(null);
     setErrorMessages([]);
-    // check if jwt is valid and hasn't expired before submission
+    // check if authExpiry is valid and hasn't expired before submission
     await checkAuthExpiry(authExpiry);
     // Only submit IOD if no validation errors found
     if (
@@ -377,10 +374,7 @@ export default function SingleObservationForm() {
       !isDeclinationOrElevationError
     ) {
       try {
-        const result = await axios.post(
-          `${API_ROOT}/submitObservation`,
-          JSON.stringify({ jwt: jwt, multiple: IOD })
-        );
+        const result = await axios.post(`${API_ROOT}/submitObservation`);
 
         if (result.data.success !== 0) {
           setSuccessCount(result.data.success);
@@ -475,7 +469,7 @@ export default function SingleObservationForm() {
 
   return (
     <Fragment>
-      {jwt === "none" ? (
+      {userAddress === "none" ? (
         <p className="app__error-message">
           You need to be logged in to submit your observations.
         </p>
@@ -1314,7 +1308,7 @@ export default function SingleObservationForm() {
                 </span>
               </NavLink>
 
-              {jwt === "none" ? null : (
+              {userAddress === "none" ? null : (
                 <button
                   className="submit__submit-button"
                   style={
@@ -1325,7 +1319,7 @@ export default function SingleObservationForm() {
                 </button>
               )}
             </div>
-            {jwt === "none" ? null : (
+            {userAddress === "none" ? null : (
               <p className="submit__submit-warning">
                 Please keep in mind that this data will be automatically
                 recorded into TruSat's catalog of orbital positions, and

--- a/src/views/AccountSettings.js
+++ b/src/views/AccountSettings.js
@@ -59,7 +59,7 @@ function UserSettings({ history }) {
 
       try {
         const result = await axiosWithCache.get(
-          `${API_ROOT}/profile?address=${userAddress}&jwt=${jwt}`
+          `${API_ROOT}/profile?address=${userAddress}`
         );
 
         profileDispatch({ type: "SET_PROFILE_DATA", payload: result.data });
@@ -69,22 +69,21 @@ function UserSettings({ history }) {
       setIsLoading(false);
     };
 
-    if (jwt !== "none" && userAddress) {
+    if (userAddress !== "none" && userAddress) {
       doFetch();
     }
-  }, [jwt, userAddress, profileDispatch]);
+  }, [userAddress, authExpiry, profileDispatch]);
 
   const submitEdit = async () => {
     setErrorMessage(``);
     setIsLoading(true);
-    // checks if jwt is valid and hasn't expired
+    // checks if auth is valid and hasn't expired
     checkAuthExpiry(authExpiry);
     // Post the edits
     try {
       await axios.post(
         `${API_ROOT}/editProfile`,
         JSON.stringify({
-          jwt: jwt,
           address: userAddress,
           username: newUsername,
           email: newEmail,
@@ -103,7 +102,7 @@ function UserSettings({ history }) {
   };
 
   const logout = () => {
-    localStorage.removeItem("trusat-jwt");
+    localStorage.removeItem("trusat-login-credentials");
     localStorage.removeItem("trusat-allow-cookies");
     history.push(`/`);
     window.location.reload();
@@ -113,7 +112,7 @@ function UserSettings({ history }) {
     <p className="app__error-message">Something went wrong... {errorMessage}</p>
   ) : isLoading ? (
     <Spinner />
-  ) : jwt === "none" ? (
+  ) : userAddress === "none" ? (
     <div className="app__error-message">
       You need to login{" "}
       <NavLink className="app__nav-link app__link" to="/login">

--- a/src/views/AccountSettings.js
+++ b/src/views/AccountSettings.js
@@ -13,13 +13,13 @@ import PrivacySettings from "../user/components/PrivacySettings";
 import SecuritySettings from "../user/components/SecuritySettings";
 import Spinner from "../app/components/Spinner";
 import Button from "../app/components/Button";
-import { checkJwt } from "../auth/auth-helpers";
+import { checkAuthExpiry } from "../auth/auth-helpers";
 
 function UserSettings({ history }) {
   const profileDispatch = useProfileDispatch();
   const { profileData } = useProfileState();
 
-  const { jwt, userAddress } = useAuthState();
+  const { userAddress, authExpiry } = useAuthState();
   // Profile settings
   const [newUsername, setNewUsername] = useState("");
   const [newEmail, setNewEmail] = useState("");
@@ -54,8 +54,8 @@ function UserSettings({ history }) {
     const doFetch = async () => {
       setErrorMessage(``);
       setIsLoading(true);
-      // checks if jwt is valid and hasn't expired
-      checkJwt(jwt);
+      // checks if auth is valid and hasn't expired
+      checkAuthExpiry(authExpiry);
 
       try {
         const result = await axiosWithCache.get(
@@ -78,7 +78,7 @@ function UserSettings({ history }) {
     setErrorMessage(``);
     setIsLoading(true);
     // checks if jwt is valid and hasn't expired
-    checkJwt(jwt);
+    checkAuthExpiry(authExpiry);
     // Post the edits
     try {
       await axios.post(

--- a/src/views/AccountSettings.js
+++ b/src/views/AccountSettings.js
@@ -92,7 +92,8 @@ function UserSettings({ history }) {
           new_station_names: newStationNames,
           new_station_notes: newStationNotes,
           deleted_stations: deletedStations
-        })
+        }),
+        { withCredentials: true }
       );
       // refresh the page to pull the latest data just posted
       window.location.reload();

--- a/src/views/AddStation.js
+++ b/src/views/AddStation.js
@@ -3,12 +3,12 @@ import axios from "axios";
 import { API_ROOT, toolTipCopy } from "../app/app-helpers";
 import { useAuthState } from "../auth/auth-context";
 import { QuestionMarkToolTip } from "../app/app-helpers";
-import { checkJwt } from "../auth/auth-helpers";
+import { checkAuthExpiry } from "../auth/auth-helpers";
 import Spinner from "../app/components/Spinner";
 import CircleCheck from "../assets/CircleCheck.svg";
 
 export default function AddStation() {
-  const { jwt } = useAuthState();
+  const { userAddress, authExpiry } = useAuthState();
   // form state
   const [stationName, setStationName] = useState(``);
   // const [latitudeSign, setLatitudeSign] = useState(`?`);
@@ -36,14 +36,13 @@ export default function AddStation() {
     setErrorMessage(``);
     setSuccessfullyAddedStation(``);
     setIsLoading(true);
-    // checks if jwt is valid and hasn't expired
-    checkJwt(jwt);
+    // checks if auth is valid and hasn't expired
+    checkAuthExpiry(authExpiry);
     // if no errors
     try {
       const result = await axios.post(
         `${API_ROOT}/generateStation`,
         JSON.stringify({
-          jwt: jwt,
           station: stationName,
           // latitude: `${latitudeSign}${latitude}`,
           // longitude: `${longitudeSign}${longitude}`,
@@ -66,7 +65,7 @@ export default function AddStation() {
     <div className="add-station">
       <h1 className="static-page__main-header--small">Add a location</h1>
       {/* Prompt user to log in so they can create a station */}
-      {jwt === "none" ? (
+      {userAddress === "none" ? (
         <p className="app__error-message">
           You need to be logged in to add a station location.
         </p>
@@ -223,7 +222,7 @@ export default function AddStation() {
         ) : (
           <Fragment>
             {/* Only render button to submit form if user is logged in */}
-            {jwt === "none" ? null : (
+            {userAddress === "none" ? null : (
               <button type="submit" className="station-form__button">
                 Add station
               </button>

--- a/src/views/AddStation.js
+++ b/src/views/AddStation.js
@@ -50,7 +50,8 @@ export default function AddStation() {
           longitude: longitude,
           elevation: elevation,
           notes: notes
-        })
+        }),
+        { withCredentials: true }
       );
       console.log(result);
       setSuccessfullyAddedStation(result.data.station_id);

--- a/src/views/LogIn.js
+++ b/src/views/LogIn.js
@@ -10,9 +10,9 @@ export default function LogIn() {
   return (
     <div className="log-in__wrapper">
       <h1 className="log-in__header">
-        {userAddress ? "You're logged in" : "Log in"}
+        {userAddress !== "none" ? "You're logged in" : "Log in"}
       </h1>
-      {userAddress ? (
+      {userAddress !== "none" ? (
         <div className="login__success-wrapper">
           <NavLink className="app__nav-link" to={`/profile/${userAddress}`}>
             <span className="app__button--white">Go to Profile</span>

--- a/src/views/Profile.js
+++ b/src/views/Profile.js
@@ -4,13 +4,11 @@ import ProfileHeader from "../profile/components/ProfileHeader";
 import ObjectsCollectedTable from "../profile/components/ObjectsCollectedTable";
 import ObservationsTable from "../profile/components/ObservationsTable";
 import Spinner from "../app/components/Spinner";
-import { useAuthState } from "../auth/auth-context";
 import { isAddress } from "../auth/auth-helpers";
 import { useProfileDispatch } from "../profile/profile-context";
 
 export default function Profile({ match }) {
   const addressFromRoute = match.params.address;
-  const { jwt } = useAuthState();
   const profileDispatch = useProfileDispatch();
 
   const [isAddressError, setIsAddressError] = useState(false);
@@ -20,15 +18,13 @@ export default function Profile({ match }) {
     if (!isAddress(addressFromRoute)) {
       setIsAddressError(true);
     } else {
-      if (typeof jwt === "string") {
-        doFetch(`/profile?address=${addressFromRoute}&jwt=${jwt}`);
-      }
+      doFetch(`/profile?address=${addressFromRoute}`);
     }
 
     if (data.length !== 0) {
       profileDispatch({ type: "SET_PROFILE_DATA", payload: data });
     }
-  }, [jwt, addressFromRoute, doFetch, data, profileDispatch]);
+  }, [addressFromRoute, doFetch, data, profileDispatch]);
 
   return isAddressError ? (
     <p className="app__error-message">

--- a/src/views/TestCookie.js
+++ b/src/views/TestCookie.js
@@ -62,13 +62,10 @@ export default function TestCookie() {
 // }
 
 // export default function TestCookie() {
-//   // const [{ data, isLoading, errorMessage }, doFetch] = useTrusatGetApi();
 //   const [isLoading, setIsLoading] = useState(false);
 //   const [errorMessage, setErrorMessage] = useState(``);
 
 //   useEffect(() => {
-//     // doFetch(`/cookieMonster`);
-
 //     async function fetchCookie() {
 //       setIsLoading(true);
 

--- a/src/views/VerifyClaimAccount.js
+++ b/src/views/VerifyClaimAccount.js
@@ -99,7 +99,7 @@ export default function VerifyClaimAccount({ match }) {
     <div className="verify-claim-account__wrapper">
       <h1 className="verify-claim-account__header">Verify Claimed Account</h1>
       {/* Don't show the form when user has successfully claimed, i.e. they received an email containing a secret 
-      Or if JWT has expired after 24 hours
+      Or if auth session has expired after 24 hours
       */}
       {!isSuccess && !isExpired ? (
         <form

--- a/src/views/VerifyClaimAccount.js
+++ b/src/views/VerifyClaimAccount.js
@@ -80,10 +80,10 @@ export default function VerifyClaimAccount({ match }) {
           })
         );
         setIsSuccess(true);
-        authDispatch({ type: "SET_JWT", payload: response.data.jwt });
+        //authDispatch({ type: "SET_JWT", payload: response.data.jwt });
         const { address } = await jwt_decode(response.data.jwt);
         authDispatch({ type: "SET_USER_ADDRESS", payload: address });
-        localStorage.setItem("trusat-jwt", response.data.jwt);
+        // localStorage.setItem("trusat-jwt", response.data.jwt);
       } catch (error) {
         setErrorMessage(error.response.data);
       }


### PR DESCRIPTION
- JWT no longer stored or retrieved from local storage to ensure authentication of users. Instead, "Login Credentials" - consisting of the users eth address and expiry date (for their logged in state) now retrieved 
- `useTrusatPostApi` helper now deleted as it was not used in the app anywhere
- `NavBar` component now uses the user' eth address as opposed to the JWT to ascertain if they are logged in or now (for conditional rendering purposes)
- `auth-context` no longer supports storage of jwt in app state, and instead now has the users eth address and expiry of their logged in state
- `{ withCredentials: true }` flag added to all axios calls that require the backend to avail of the jwt present in cookies for auth purposes
- `checkJwt` helper converted to `checkAuthExpiry` and corresponding test is updated to support the change 
- `jwt` as a value appended to any post request urls is now removed
