### PR TITLE
Add application/json header to post requests

### DIFF
--- a/src/auth/auth-helpers.js
+++ b/src/auth/auth-helpers.js
@@ -44,7 +44,11 @@ export const retrieveNonce = async ({ email, address }) => {
         JSON.stringify({
           email: email,
           address: address
-        })
+        }), {
+          headers: {
+            'Content-Type': 'application/json',
+          }
+        }
       );
 
       return result.data.nonce;
@@ -104,7 +108,11 @@ export const signUp = async ({ email, address, signedMessage, secret }) => {
         address: address,
         signedMessage: signedMessage.signature,
         secret: secret
-      })
+      }), {
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      }
     );
     // returns true is successful - i.e. the user receives an email
     return result.data;
@@ -127,7 +135,11 @@ export const retrieveLoginCredentials = async ({
         address: address,
         signedMessage: signedMessage.signature
       }),
-      { withCredentials: true }
+      { withCredentials: true,
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      }
     );
 
     return response.data;
@@ -163,7 +175,11 @@ export const retrieveMetamaskLoginCredentials = async ({
         address: address,
         signedMessage: metamaskSignedMessage
       }),
-      { withCredentials: true }
+      { withCredentials: true,
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      }
     );
     return response.data;
   } catch (error) {

--- a/src/submissions/components/MultipleObservationForm.js
+++ b/src/submissions/components/MultipleObservationForm.js
@@ -31,7 +31,11 @@ export default function MultipleObservationForm() {
       const result = await axios.post(
         `${API_ROOT}/submitObservation`,
         JSON.stringify({ multiple: pastedIODs }),
-        { withCredentials: true }
+        { withCredentials: true,
+          headers: {
+            'Content-Type': 'application/json',
+          }
+        }
       );
       setPastedIODs("");
 

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -101,7 +101,10 @@ export default function SingleObservationForm() {
           `${API_ROOT}/getObservationStations`,
           JSON.stringify({}),
           {
-            withCredentials: true
+            withCredentials: true,
+            headers: {
+              'Content-Type': 'application/json',
+            }
           }
         );
         // sort stations by most observations
@@ -391,7 +394,10 @@ export default function SingleObservationForm() {
           `${API_ROOT}/submitObservation`,
           JSON.stringify({ multiple: IOD }),
           {
-            withCredentials: true
+            withCredentials: true,
+            headers: {
+              'Content-Type': 'application/json',
+            }
           }
         );
 

--- a/src/views/AccountSettings.js
+++ b/src/views/AccountSettings.js
@@ -94,7 +94,11 @@ function UserSettings({ history }) {
           new_station_notes: newStationNotes,
           deleted_stations: deletedStations
         }),
-        { withCredentials: true }
+        { withCredentials: true,
+          headers: {
+            'Content-Type': 'application/json',
+          }
+        }
       );
       // refresh the page to pull the latest data just posted
       window.location.reload();

--- a/src/views/AddStation.js
+++ b/src/views/AddStation.js
@@ -51,7 +51,11 @@ export default function AddStation() {
           elevation: elevation,
           notes: notes
         }),
-        { withCredentials: true }
+        { withCredentials: true,
+          headers: {
+            'Content-Type': 'application/json',
+          }
+        }
       );
       setSuccessfullyAddedStation(result.data.station_id);
     } catch (error) {

--- a/src/views/ClaimAccount.js
+++ b/src/views/ClaimAccount.js
@@ -20,7 +20,11 @@ export default function ClaimAccount() {
         `${API_ROOT}/claimAccount`,
         JSON.stringify({
           email: email
-        })
+        }), {
+          headers: {
+            'Content-Type': 'application/json',
+          }
+        }
       );
 
       if (response.data.result === true && !errorMessage) {

--- a/src/views/VerifyClaimAccount.js
+++ b/src/views/VerifyClaimAccount.js
@@ -77,7 +77,11 @@ export default function VerifyClaimAccount({ match }) {
             jwt: match.params.jwt,
             address: wallet.signingKey.address,
             secret: secret
-          })
+          }), {
+            headers: {
+              'Content-Type': 'application/json',
+            }
+          }
         );
         setIsSuccess(true);
         const { address } = await jwt_decode(response.data.jwt);


### PR DESCRIPTION
application/json header was missing from post requests. The header data was being interpreted as text which is not as easy to parse with built-in libraries.