### PR TITLE
Update API ROOT for development server

### DIFF
--- a/src/app/app-helpers.js
+++ b/src/app/app-helpers.js
@@ -23,7 +23,7 @@ export const deleteCookies = () => {
 };
 
 export const API_ROOT =
-  process.env.REACT_APP_API_ROOT || `https://api.consensys.space:5000`;
+  process.env.REACT_APP_API_ROOT || `https://devvymcdevface.trusat.org`;
 
 export const axiosWithCache = axios.create({
   baseURL: "/",


### PR DESCRIPTION
- This is the new endpoint for TruSat when operating the app on local machine, i.e. `localhost:3000`