### PR TITLE
Update routes to utilize PDF iframe hack

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,8 +29,8 @@ import Charter from "./views/Charter";
 import Whitepaper from "./views/Whitepaper";
 import FAQ from "./views/FAQ";
 import ReactGA from "react-ga";
-// import PrivacyPolicy from "./views/PrivacyPolicy";
-// import Terms from "./views/Terms";
+import PrivacyPolicy from "./views/PrivacyPolicy";
+import Terms from "./views/Terms";
 import SubscriptionConfirmed from "./views/SubscriptionConfirmed";
 import TestPilotConfirmed from "./views/TestPilotConfirmed";
 import ChatIcon from "./app/components/ChatIcon";
@@ -119,8 +119,8 @@ export default function App() {
           <Route path="/whitepaper" component={Whitepaper} />
           <Route path="/faq" component={FAQ} />
           <Route path="/charter" component={Charter} />
-          {/* <Route path="/privacy" component={PrivacyPolicy} />
-          <Route path="/terms" component={Terms} /> */}
+          <Route path="/privacy" component={PrivacyPolicy} />
+          <Route path="/terms" component={Terms} />
           {/* User is sent to this route when they complete a mail chimp sign up */}
           <Route
             path="/subscription-confirmed"

--- a/src/app/components/CookieBanner.js
+++ b/src/app/components/CookieBanner.js
@@ -1,5 +1,5 @@
 import React from "react";
-// import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import { setCookies, deleteCookies } from "../app-helpers";
 import Button from "../../app/components/Button";
 
@@ -30,17 +30,9 @@ export default function CookieBanner({ isBannerOpen, setIsBannerOpen }) {
           text="No Thanks"
         ></Button>
       </div>
-      {/* <NavLink className="app__nav-link app__hide-on-mobile" to="/policy">
+      <NavLink className="app__nav-link " to="/policy">
         <p className="cookie-banner__link">Read our privacy policy</p>
-      </NavLink> */}
-      <a
-        className="cookie-banner__link app__hide-on-desktop"
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://trusat-assets.s3.amazonaws.com/Privacy+Policy+for+TruSat.org+_12-19-19.pdf"
-      >
-        Read our privacy policy
-      </a>
+      </NavLink>
     </div>
   ) : null;
 }

--- a/src/app/components/Footer.js
+++ b/src/app/components/Footer.js
@@ -1,5 +1,5 @@
 import React from "react";
-// import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import SocialIcons from "../../app/components/SocialIcons";
 
 export default function Footer() {
@@ -7,34 +7,13 @@ export default function Footer() {
     <div className="footer">
       <div className="footer__content">
         <div className="footer__text-links-wrapper">
-          {/* <NavLink
-            className="app__nav-link footer__text-link app__hide-on-mobile"
-            to="/terms"
-          >
+          <NavLink className="app__nav-link footer__text-link " to="/terms">
             terms
-          </NavLink> */}
-          <a
-            className="app__link footer__text-link"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://trusat-assets.s3.amazonaws.com/trusat_terms_of_use.pdf"
-          >
-            terms
-          </a>
-          {/* <NavLink
-            className="app__nav-link footer__text-link app__hide-on-mobile"
-            to="/privacy"
-          >
+          </NavLink>
+
+          <NavLink className="app__nav-link footer__text-link " to="/privacy">
             privacy
-          </NavLink> */}
-          <a
-            className="app__link footer__text-link"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://trusat-assets.s3.amazonaws.com/Privacy+Policy+for+TruSat.org+_12-19-19.pdf"
-          >
-            privacy
-          </a>
+          </NavLink>
         </div>
         <SocialIcons />
       </div>

--- a/src/app/components/NavBar.js
+++ b/src/app/components/NavBar.js
@@ -111,21 +111,19 @@ function NavBar(props) {
                 : "nav-bar__link-wrapper--lowlight"
             }
           >
-            <a
+            <NavLink
               className={
-                path === `/whitepaper`
+                path === "/whitepaper"
                   ? "app__nav-link nav-bar__link--highlight"
                   : path === "/"
                   ? "app__nav-link nav-bar__link--lowlight--welcome"
                   : "app__nav-link nav-bar__link--lowlight"
               }
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://trusat-assets.s3.amazonaws.com/TruSat+White+Paper_v3.0.pdf"
+              to="/whitepaper"
             >
               <img className="app__nav__icon" src={IconLight} alt="icon"></img>
-              WHITE PAPER
-            </a>
+              WHITEPAPER
+            </NavLink>
           </div>
         )}
 

--- a/src/views/About.js
+++ b/src/views/About.js
@@ -103,19 +103,11 @@ export default function About() {
           <div className="about__block-pair">
             <div className="about__block--left">
               <NavLink
-                className="app__nav-link static-page__link static-page__link--highlight app__hide-on-mobile app__hide-on-tablet"
+                className="app__nav-link static-page__link static-page__link--highlight"
                 to="/whitepaper"
               >
                 The TruSat white paper
               </NavLink>
-              <a
-                className="static-page__link static-page__link--highlight app__show-on-tablet app__hide-on-desktop"
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://trusat-assets.s3.amazonaws.com/TruSat+White+Paper_v3.0.pdf"
-              >
-                The TruSat white paper
-              </a>
             </div>
             <div className="about__block--right">
               <p className="static-page__copy">

--- a/src/views/FAQ.js
+++ b/src/views/FAQ.js
@@ -436,21 +436,9 @@ export default function FAQ() {
       <section className="static-page__section">
         <p className="static-page__copy">
           Curious for a technical deep dive into how TruSat works? Check out the{" "}
-          <NavLink
-            className="app__nav-link static-page__link app__hide-on-mobile app__hide-on-tablet"
-            to="/whitepaper"
-          >
+          <NavLink className="app__nav-link static-page__link" to="/whitepaper">
             TruSat white paper
           </NavLink>
-          <a
-            className="static-page__link app__show-on-tablet app__hide-on-desktop"
-            target="_blank"
-            and
-            rel="noopener noreferrer"
-            href="https://trusat-assets.s3.amazonaws.com/TruSat+White+Paper_v3.0.pdf"
-          >
-            The TruSat white paper.
-          </a>
         </p>
         <p className="static-page__copy">
           Have any other questions? Reach out to us at{" "}

--- a/src/views/PrivacyPolicy.js
+++ b/src/views/PrivacyPolicy.js
@@ -3,8 +3,9 @@ import React from "react";
 export default function PrivacyPolicy() {
   return (
     <div className="pdf__wrapper">
-      <embed
-        src="https://trusat-assets.s3.amazonaws.com/Privacy+Policy+for+TruSat.org+_12-19-19.pdf"
+      <iframe
+        title="TruSat privacy policy"
+        src="https://drive.google.com/viewerng/viewer?embedded=true&url=https://trusat-assets.s3.amazonaws.com/Privacy+Policy+for+TruSat.org+_12-19-19.pdf"
         type="application/pdf"
         width="100%"
         height="850"

--- a/src/views/Terms.js
+++ b/src/views/Terms.js
@@ -3,8 +3,9 @@ import React from "react";
 export default function Terms() {
   return (
     <div className="terms__wrapper">
-      <embed
-        src="https://trusat-assets.s3.amazonaws.com/trusat_terms_of_use.pdf"
+      <iframe
+        title="TruSat terms of use"
+        src="https://drive.google.com/viewerng/viewer?embedded=true&url=https://trusat-assets.s3.amazonaws.com/trusat_terms_of_use.pdf"
         type="application/pdf"
         width="100%"
         height="850"

--- a/src/views/Whitepaper.js
+++ b/src/views/Whitepaper.js
@@ -4,6 +4,7 @@ export default function Whitepaper() {
   return (
     <div className="pdf__wrapper">
       <iframe
+        title="TruSat Whitepaper"
         src="https://drive.google.com/viewerng/viewer?embedded=true&url=https://trusat-assets.s3.amazonaws.com/TruSat+White+Paper_v3.0.pdf"
         type="application/pdf"
         width="100%"


### PR DESCRIPTION
closes #236 

- Routes updated
- Links to routes updated
- Components to render various externally hosted PDFs now inside an iFrame as opposed to opening a new tab to view directly from AWS. 