### PR TITLE
Fixed gap in error messaging found in auth components

### DIFF
--- a/src/auth/components/LoginForm.js
+++ b/src/auth/components/LoginForm.js
@@ -17,10 +17,10 @@ export default function LoginForm() {
   const [password, setPassword] = useState("");
   const [secret, setSecret] = useState("");
   const [showPrivateKeyError, setShowPrivateKeyError] = useState(false);
-  const [isError, setIsError] = useState(false);
+  const [error, setError] = useState(``);
 
   const handleLogin = async () => {
-    setIsError(false);
+    setError(``);
     authDispatch({ type: "AUTHENTICATING", payload: true });
     // get private key from the secret using the users password
     const privateKey = decryptSecret(secret, password);
@@ -34,6 +34,10 @@ export default function LoginForm() {
     let wallet = new ethers.Wallet(privateKey);
     // get unique nonce from server for this user
     const nonce = await retrieveNonce({ address: wallet.signingKey.address });
+    // if false in returned instead of nonce of type string
+    if (!nonce) {
+      setError("log in failed as a random nonce was not received");
+    }
     // sign the nonce
     const signedMessage = signMessage({ nonce, wallet });
     // get JSON web token that will be used to keep user logged in
@@ -45,7 +49,7 @@ export default function LoginForm() {
     });
     // do not attempt to hit /profile unless auth hasn't expired
     if (!loginCredentials) {
-      setIsError(true);
+      setError(`Log in failed because your log in credentials are not valid`);
       authDispatch({ type: "AUTHENTICATING", payload: false });
       return;
     }
@@ -69,8 +73,8 @@ export default function LoginForm() {
     authDispatch({ type: "AUTHENTICATING", payload: false });
   };
 
-  return isError ? (
-    <p className="app__error-message">Something went wrong ...</p>
+  return error ? (
+    <p className="app__error-message">{error}</p>
   ) : (
     <form
       className="app__form"

--- a/src/auth/components/MetaMask.js
+++ b/src/auth/components/MetaMask.js
@@ -13,7 +13,7 @@ const web3 = new Web3(Web3.givenProvider || window.ethereum);
 export default function MetaMask({ buttonText, GAEvent }) {
   const { isAuthenticating } = useAuthState();
   const authDispatch = useAuthDispatch();
-  const [isError, setIsError] = useState(false);
+  const [error, setError] = useState(``);
 
   const handleClick = async () => {
     if (window.ethereum.selectedAddress) {
@@ -34,11 +34,16 @@ export default function MetaMask({ buttonText, GAEvent }) {
 
   // For both signup and login metamask flows
   const handleMetamaskAuth = async () => {
-    setIsError(false);
+    setError(``);
 
     const address = web3._provider.selectedAddress;
 
     const nonce = await retrieveNonce({ address });
+
+    // if false in returned instead of nonce of type string
+    if (!nonce) {
+      setError("log in failed as a random nonce was not received");
+    }
 
     const metamaskSignedMessage = await metamaskSignMessage({ nonce, address });
 
@@ -50,7 +55,7 @@ export default function MetaMask({ buttonText, GAEvent }) {
       });
       // only log user in and add credentaisl to local storage if credentials are valid
       if (!metamaskLoginCredentials) {
-        setIsError(true);
+        setError(`Log in failed because your log in credentials are not valid`);
       } else {
         // Add address to auth state
         authDispatch({ type: "SET_USER_ADDRESS", payload: address });
@@ -80,9 +85,7 @@ export default function MetaMask({ buttonText, GAEvent }) {
       <span className="app__button--white" onClick={handleClick}>
         {isAuthenticating ? "...Loading" : buttonText}
       </span>
-      {isError ? (
-        <p className="app__error-message">Something went wrong...</p>
-      ) : null}
+      {error ? <p className="app__error-message">{error}</p> : null}
     </Fragment>
   );
 }

--- a/src/auth/components/SignupForm.js
+++ b/src/auth/components/SignupForm.js
@@ -25,7 +25,7 @@ export default function SignupForm({ setIsSuccess }) {
   );
   // used to prompt user to either log in or claim their account
   const [isAlreadySignedUp, setIsAlreadySignedUp] = useState(false);
-  const [isError, setIsError] = useState(false);
+  const [error, setError] = useState(``);
 
   const handleFormValidation = () => {
     setShowInvalidPasswordError(false);
@@ -48,7 +48,7 @@ export default function SignupForm({ setIsSuccess }) {
     const inputsAreValid = handleFormValidation();
 
     if (inputsAreValid) {
-      setIsError(false);
+      setError(``);
       setIsSuccess(false);
       authDispatch({ type: "AUTHENTICATING", payload: true });
       // create a new wallet for user
@@ -63,6 +63,10 @@ export default function SignupForm({ setIsSuccess }) {
         setIsAlreadySignedUp(true);
         authDispatch({ type: "AUTHENTICATING", payload: false });
         return;
+      }
+      // if false in returned instead of nonce of type string
+      if (!nonce) {
+        setError("log in failed as a random nonce was not received");
       }
       // sign the nonce
       const signedMessage = signMessage({ nonce, wallet });
@@ -79,7 +83,9 @@ export default function SignupForm({ setIsSuccess }) {
       if (signUpSuccess) {
         setIsSuccess(true);
       } else {
-        setIsError(true);
+        setError(
+          `Sign up has failed to send your secret to your email, please try again later`
+        );
       }
 
       authDispatch({ type: "AUTHENTICATING", payload: false });
@@ -98,9 +104,7 @@ export default function SignupForm({ setIsSuccess }) {
           handleSignup();
         }}
       >
-        {isError ? (
-          <p className="app__error-message">Something went wrong ...</p>
-        ) : null}
+        {error ? <p className="app__error-message">{error}</p> : null}
 
         {isAlreadySignedUp ? (
           <Fragment>


### PR DESCRIPTION
Add advanced error messaging to `MetaMask`, `LoginForm` and `SignUpForm` components

closes #204 