### PR TITLE
Tweak Download Observations feature

### DIFF
--- a/src/user/components/DataSettings.js
+++ b/src/user/components/DataSettings.js
@@ -1,15 +1,20 @@
 import React from "react";
 import { toolTip, emails } from "../../app/app-helpers";
 import DownloadObservations from "../../user/components/DownloadObservations";
+import { useProfileState } from "../../profile/profile-context";
 
 export default function PrivacySettings() {
+  const { profileData } = useProfileState();
+
   return (
     <section className="data-settings__wrapper">
       <h2 className="data-settings__heading">
         <p>MY DATA</p>
       </h2>
       <div className="data-settings__button-wrapper">
-        <DownloadObservations />
+        <DownloadObservations
+          observationCount={profileData.observation_count}
+        />
         <a
           className="data-settings__remove-text"
           href={`mailto:${emails.remove}`}

--- a/src/user/components/DownloadObservations.js
+++ b/src/user/components/DownloadObservations.js
@@ -12,6 +12,7 @@ export default class DownloadObservations extends React.Component {
   linkRef = React.createRef();
 
   download = async () => {
+    this.setState({ errorMessage: `` });
     this.setState({ isLoading: true });
 
     try {

--- a/src/user/components/DownloadObservations.js
+++ b/src/user/components/DownloadObservations.js
@@ -1,10 +1,8 @@
 import React from "react";
 import { API_ROOT } from "../../app/app-helpers";
 import axios from "axios";
-import { useProfileState } from "../../profile/profile-context";
 
 export default class DownloadObservations extends React.Component {
-  // const { profileData } = useProfileState();
   state = {
     isLoading: false,
     errorMessage: "",
@@ -57,7 +55,9 @@ export default class DownloadObservations extends React.Component {
     return (
       <div>
         <span className="download-observations" onClick={this.download}>
-          {this.state.isLoading ? `...Loading` : `Download my Observations`}
+          {this.state.isLoading
+            ? `...Loading`
+            : `Download my ${this.props.observationCount} Observations`}
         </span>
 
         {this.state.errorMessage ? (


### PR DESCRIPTION
- As the `DownloadObservations` class component cannot access the `useProfileState` helper (only available to functional components), this change uses the state provider inside the `DataSettings` parent component and passes the `observation_count` value down to `DownloadObservations` as a prop - which is then rendered by the button. 
- Adds a reset of the `errorMessage` state value each time the button is clicked to improve UX