### PR TITLE
Add About static page and update links to TruSat Learn

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,7 @@ import VerifyClaimAccount from "./views/VerifyClaimAccount";
 import CookieBanner from "./app/components/CookieBanner";
 import Footer from "./app/components/Footer";
 import Whitepaper from "./views/Whitepaper";
+import About from "./views/About";
 import ReactGA from "react-ga";
 import PrivacyPolicy from "./views/PrivacyPolicy";
 import Terms from "./views/Terms";
@@ -96,6 +97,7 @@ export default function App() {
         <Switch>
           <Route exact path="/" component={Welcome} />
           <Route path="/catalog/:catalogFilter" component={Catalog} />
+          <Route path="/about" component={About} />
           <Route path="/submit/:form" component={Submit} />
           <Route path="/submit" component={Submit} />
           <Route path="/object/:number" component={ObjectInfo} />

--- a/src/app/components/BurgerMenu.js
+++ b/src/app/components/BurgerMenu.js
@@ -59,17 +59,10 @@ export default function BurgerMenu() {
         </NavLink>
       ) : null}
 
-      <div>
+      <NavLink onClick={() => closeMenu()} to={`/about`}>
         <img className="app__nav__icon" src={IconGlobe} alt="icon"></img>
-        <a
-          className="app__nav-link nav-bar__link--lowlight--welcome"
-          href="https://learn.trusat.org/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          About
-        </a>
-      </div>
+        About
+      </NavLink>
 
       <div>
         <img className="app__nav__icon" src={IconQuestion} alt="icon"></img>

--- a/src/app/components/NavBar.js
+++ b/src/app/components/NavBar.js
@@ -132,15 +132,19 @@ function NavBar(props) {
               : "nav-bar__link-wrapper--lowlight"
           }
         >
-          <img className="app__nav__icon" src={IconGlobe} alt="icon"></img>
-          <a
-            className="app__nav-link nav-bar__link--lowlight--welcome"
-            href="https://learn.trusat.org/"
-            target="_blank"
-            rel="noopener noreferrer"
+          <NavLink
+            className={
+              path === `/about`
+                ? "app__nav-link nav-bar__link--highlight"
+                : path === "/"
+                ? "app__nav-link nav-bar__link--lowlight--welcome"
+                : "app__nav-link nav-bar__link--lowlight"
+            }
+            to={`/about`}
           >
+            <img className="app__nav__icon" src={IconGlobe} alt="icon"></img>
             ABOUT
-          </a>
+          </NavLink>
         </div>
 
         <div

--- a/src/views/About.js
+++ b/src/views/About.js
@@ -1,0 +1,179 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import Partners from "../app/components/Partners";
+import SocialIcons from "../app/components/SocialIcons";
+import MailingListForm from "../app/components/MailingListForm";
+import Advisors from "../app/components/Advisors";
+
+export default function About() {
+  return (
+    <div className="static-page__wrapper">
+      <section className="static-page__section about__about-trusat-section">
+        <h1 className="static-page__main-header--small">
+          TruSat is a citizen-powered, open source system for creating a
+          globally-accessible, trusted record of satellite orbital positions.
+        </h1>
+        <p className="static-page__copy about__deck">
+          TruSat is primarily designed to enable the assessment of satellite
+          operations in the context of space sustainability standards.
+        </p>
+
+        <div className="about__block-wrapper">
+          <div className="about__block-pair">
+            <div className="about__block--left">
+              <img
+                className="about__illustration"
+                src="https://trusat-assets.s3.amazonaws.com/illustration-observation2-360px.jpg"
+                alt="Illustration"
+              ></img>
+            </div>
+            <div className="about__block--right">
+              <p className="static-page__copy">
+                Citizen satellite trackers are the eyes of the TruSat system.
+              </p>
+            </div>
+          </div>
+          <div className="about__block-pair">
+            <div className="about__block--left">
+              <img
+                className="about__illustration"
+                src="https://trusat-assets.s3.amazonaws.com/illustration-posat2-360px.jpg"
+                alt="Illustration"
+              ></img>
+            </div>
+            <div className="about__block--right">
+              <p className="static-page__copy">
+                The TruSat software merges observations of a satellite from
+                around the world into a transparent record of its location.
+              </p>
+            </div>
+          </div>
+          <div className="about__block-pair">
+            <div className="about__block--left">
+              <img
+                className="about__illustration"
+                src="https://trusat-assets.s3.amazonaws.com/illustration-gameplan-360px.jpg"
+                alt="Illustration"
+              ></img>
+            </div>
+            <div className="about__block--right">
+              <p className="static-page__copy">
+                Space sustainability advocates keep the system focused on the
+                highest space sustainability priorities. And they can use
+                TruSat’s transparent record to foster accountability for
+                sustainable orbital operations.
+              </p>
+            </div>
+          </div>
+          <div className="about__block-pair">
+            <div className="about__block--left">
+              <img
+                className="about__illustration"
+                src="https://trusat-assets.s3.amazonaws.com/illustration-open_source-360px.jpg"
+                alt="Illustration"
+              ></img>
+            </div>
+            <div className="about__block--right">
+              <p className="static-page__copy">
+                The TruSat Open Source Community maintains and advances the
+                TruSat software.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="about__block-wrapper">
+          <h2 className="static-page__sub-header static-page__sub-header--margin_fix">
+            LINKS
+          </h2>
+          <div className="about__block-pair">
+            <div className="about__block--left">
+              <a
+                className="app__nav-link static-page__link static-page__link--highlight"
+                href="https://learn.trusat.org/docs/FAQ"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Frequently asked questions
+              </a>
+            </div>
+            <div className="about__block--right">
+              <p className="static-page__copy">
+                Learn the ins and outs of TruSat.
+              </p>
+            </div>
+          </div>
+          <div className="about__block-pair">
+            <div className="about__block--left">
+              <a
+                className="app__nav-link static-page__link static-page__link--highlight"
+                href="https://learn.trusat.org/docs/overview"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                The TruSat white paper
+              </a>
+            </div>
+            <div className="about__block--right">
+              <p className="static-page__copy">
+                A technical deep dive into how TruSat works.
+              </p>
+            </div>
+          </div>
+          <div className="about__block-pair">
+            <div className="about__block--left">
+              <a
+                className="app__nav-link static-page__link static-page__link--highlight"
+                href="https://learn.trusat.org/docs/trusat-charter"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                The TruSat Charter
+              </a>
+            </div>
+            <div className="about__block--right">
+              <p className="static-page__copy">
+                TruSat's governance arrangements
+              </p>
+            </div>
+          </div>
+          <div className="about__block-pair">
+            <div className="about__block--left">
+              <a
+                className="static-page__link static-page__link--highlight"
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://discuss.trusat.org/"
+              >
+                TruSat chat
+              </a>
+            </div>
+            <div className="about__block--right">
+              <p className="static-page__copy">
+                A community forum to discuss the project and get help.
+              </p>
+            </div>
+          </div>
+        </div>
+        <Partners />
+        <Advisors />
+        <div className="about__block-wrapper">
+          <h2 className="static-page__sub-header about__sub-header--top">
+            FOLLOW TRUSAT
+          </h2>
+          <SocialIcons />
+
+          <div className="about__mailing-list-wrapper">
+            <p className="">
+              Join the mailing list to stay posted on the project
+            </p>
+            <MailingListForm
+              testPilots={false}
+              eventLabel={"About page subscribe button"}
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
- Adds static page for `About` page, with updated links that point to relevant sections in TruSat Learn documentation.
- Adds route at `/about`.
- Updates nav links in `BurgerMenu` and `NavBar` for "About" text to point to /about route as opposed to TruSat Learn.