### PR TITLE
Fix bug where error messaging was not properly handled

### DIFF
--- a/src/submissions/components/MultipleObservationForm.js
+++ b/src/submissions/components/MultipleObservationForm.js
@@ -16,11 +16,11 @@ export default function MultipleObservationForm() {
   // server provides these so we can render more specific error messages
   const [errorMessages, setErrorMessages] = useState([]);
   const { userAddress, authExpiry } = useAuthState();
-  const [isError, setIsError] = useState(false);
+  const [apiErrorMessage, setApiErrorMessage] = useState(``);
 
   const handleSubmit = async () => {
     setIsLoading(true);
-    setIsError(false);
+    setApiErrorMessage(``);
     setSuccessCount(null);
     setErrorMessages([]);
 
@@ -31,9 +31,10 @@ export default function MultipleObservationForm() {
       const result = await axios.post(
         `${API_ROOT}/submitObservation`,
         JSON.stringify({ multiple: pastedIODs }),
-        { withCredentials: true,
+        {
+          withCredentials: true,
           headers: {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json"
           }
         }
       );
@@ -55,7 +56,7 @@ export default function MultipleObservationForm() {
         });
       }
     } catch (error) {
-      setIsError(true);
+      setApiErrorMessage(error.response.data);
     }
     setIsLoading(false);
   };
@@ -119,8 +120,10 @@ export default function MultipleObservationForm() {
           ) : null}
         </div>
 
-        {isError ? (
-          <p className="app__error-message">Something went wrong...</p>
+        {apiErrorMessage ? (
+          <p className="app__error-message">
+            Something went wrong...{apiErrorMessage}
+          </p>
         ) : isLoading ? (
           <Spinner />
         ) : (

--- a/src/submissions/components/SingleObservationForm.js
+++ b/src/submissions/components/SingleObservationForm.js
@@ -83,7 +83,7 @@ export default function SingleObservationForm() {
   const [successCount, setSuccessCount] = useState(null);
   const [errorMessages, setErrorMessages] = useState([]);
   // set to true if attempt to submit fails
-  const [isError, setIsError] = useState(false);
+  const [apiErrorMessage, setApiErrorMessage] = useState(``);
   const [
     fetchObservationStationsError,
     setFetchObservationStationsError
@@ -374,7 +374,7 @@ export default function SingleObservationForm() {
   // submit the IOD
   const handleSubmit = async () => {
     setIsLoading(true);
-    setIsError(false);
+    setApiErrorMessage(``);
     setSuccessCount(null);
     setErrorMessages([]);
     // check if authExpiry is valid and hasn't expired before submission
@@ -418,7 +418,7 @@ export default function SingleObservationForm() {
           });
         }
       } catch (error) {
-        setIsError(true);
+        setApiErrorMessage(error.response.data);
       }
     } else {
       alert(`Please clear all errors in the form and try again`);
@@ -1331,8 +1331,10 @@ export default function SingleObservationForm() {
           </Fragment>
         ) : null}
 
-        {isError ? (
-          <p className="app__error-message">Something went wrong...</p>
+        {apiErrorMessage ? (
+          <p className="app__error-message">
+            Something went wrong... {apiErrorMessage}
+          </p>
         ) : isLoading ? (
           <Spinner />
         ) : (


### PR DESCRIPTION
Closes #201 

This wasn't fixed during the updates to error messaging a while back. Some context:
- There is "error messages" returned inside the success block - i.e. the api call is successful, but the format of the IODs are incorrect - and are therefore rejected by the back end. 
- This change means that instead of just error messaging provided to the user in the event of them submitting incorrectly formatted IODs...
- The user now also receive error messaging in the event that the API call to `/submitObservation` fails.